### PR TITLE
Added a --list_fw_ver option to the flash command. This will only que…

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ optional arguments:
   -h, --help            show this help message and exit
   --sys-config SYS_CONFIG
                         Path to the pre generated sys-config json
+  --list_fw_ver         List the current version of firmware and exit
   --fw-tar FW_TAR       Path to the firmware tarball
   --skip-missing-fw     If the fw packages doesn't contain the fw for a detected board, continue flashing
   --force               Force update the ROM

--- a/tt_flash/flash.py
+++ b/tt_flash/flash.py
@@ -170,7 +170,7 @@ class FlashStageResult:
     msg: str
     data: Optional[FlashData]
 
-def get_bcd_version_string(dec_ver_num):
+def get_bcd_ver_str(dec_ver_num):
     major_hex=str(f'{dec_ver_num:x}'.zfill(8))[0:2]
     minor_hex=str(f'{dec_ver_num:x}'.zfill(8))[2:4]
     patch_hex=str(f'{dec_ver_num:x}'.zfill(8))[4:6]
@@ -189,10 +189,10 @@ def get_bcd_version_string(dec_ver_num):
     bcd_ver_str="v" + major_str + "." + minor_str + "." + patch_str + "." + build_str
     return(bcd_ver_str)
 
-def get_dec_ver_string(dec_ver_num):
+def get_dec_ver_str(dec_ver_num):
     return(str(dec_ver_num).zfill(8))
 
-def get_hex_ver_string(dec_ver_num):
+def get_hex_ver_str(dec_ver_num):
     return(f"{dec_ver_num:#0{10}x}")
 
 def flash_chip_stage1(
@@ -262,13 +262,13 @@ def flash_chip_stage1(
 
         if list_fw_ver:
             print("")
-            print("\tfw_ver hex:", get_hex_ver_string(fw_version))
-            print("\tfw_ver dec:", get_dec_ver_string(fw_version))
-            print("\tfw_ver bcd:", get_bcd_version_string(fw_version))
+            print("\tfw_ver hex:", get_hex_ver_str(fw_version))
+            print("\tfw_ver dec:", get_dec_ver_str(fw_version))
+            print("\tfw_ver bcd:", get_bcd_ver_str(fw_version))
             print("")
-            print("\tbunver hex:", get_hex_ver_string(running_bundle_version))
-            print("\tbunver dec:", get_dec_ver_string(running_bundle_version))
-            print("\tbunver bcd:", get_bcd_version_string(running_bundle_version))
+            print("\tbunver hex:", get_hex_ver_str(running_bundle_version))
+            print("\tbunver dec:", get_dec_ver_str(running_bundle_version))
+            print("\tbunver bcd:", get_bcd_ver_str(running_bundle_version))
             print("")
             return FlashStageResult(
                 state=FlashStageResultState.NoFlash, data=None, msg="", can_reset=False


### PR DESCRIPTION
…ry installed

cards and print the firmware and bundle versions on the card. Note the BCD (binary coded decimal) matches the named releases in github.com/tenstorrent/tt-firmware/tags.

tt-flash flash --list_fw_ver

Device Grayskull[0] found

        fw_ver hex: 0x01070000
        fw_ver dec: 17235968
        fw_ver bcd: v1.7.0.0

        bunver hex: 0x500a0000
        bunver dec: 1342832640
        bunver bcd: v80.10.0.0

tt-flash flash -h

usage: tt-flash flash [-h] [--sys-config SYS_CONFIG] [--list_fw_ver] --fw-tar FW_TAR
                      [--skip-missing-fw] [--force] [--no-reset]

options:
  -h, --help            show this help message and exit
  --sys-config SYS_CONFIG
                        Path to the pre generated sys-config json
  --list_fw_ver         List the current version of firmware and exit
  --fw-tar FW_TAR       Path to the firmware tarball
  --skip-missing-fw     If the fw packages doesn't contain the fw for a detected board,
                        continue flashing
  --force               Force update the ROM
  --no-reset            Do not reset devices at the end of flash