### PR TITLE
Added fallback for when telemetry cannot be read on blackhole

### DIFF
--- a/tt_flash/chip.py
+++ b/tt_flash/chip.py
@@ -248,7 +248,7 @@ class BhChip(TTChip):
             exception = e
 
         return FwVersion(
-            allow_exception=False, exception=exception, running=running, spi=spi
+            allow_exception=True, exception=exception, running=running, spi=spi
         )
 
 


### PR DESCRIPTION
Added code to fallback to a default FW bundle version when telemetry is not available on blackhole.

This PR requires https://github.com/tenstorrent/luwen/pull/20 so that `get_telemetry` will correctly raise an exception when the telemetry address set by the ARC core is invalid.