### PR TITLE
chore: bump pyyaml from 6.0.1 to 6.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
-  "pyyaml == 6.0.1",
+  "pyyaml == 6.0.2",
   "pyluwen @ git+https://github.com/tenstorrent/luwen.git@v0.6.4#subdirectory=crates/pyluwen",
   "tabulate == 0.9.0",
   "tomli == 2.0.1; python_version < '3.11'",


### PR DESCRIPTION
Needed to bump pyyaml so that tt-flash could resolve dependencies and build for Nix. The entire build process for pyyaml 6.0.1 falls apart with this error:
```
pyyaml> Traceback (most recent call last):
pyyaml>   File "/nix/store/hh1r1pf4biv0yszc3smfq7gbl241gy43-python3.13-pyproject-hooks-1.2.0/lib/python3.13/site-packages/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
pyyaml>     main()
pyyaml>     ~~~~^^
pyyaml>   File "/nix/store/hh1r1pf4biv0yszc3smfq7gbl241gy43-python3.13-pyproject-hooks-1.2.0/lib/python3.13/site-packages/pyproject_hooks/_in_process/_in_process.py", line 373, in main
pyyaml>     json_out["return_val"] = hook(**hook_input["kwargs"])
pyyaml>                              ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
pyyaml>   File "/nix/store/hh1r1pf4biv0yszc3smfq7gbl241gy43-python3.13-pyproject-hooks-1.2.0/lib/python3.13/site-packages/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
pyyaml>     return hook(config_settings)
pyyaml>   File "/nix/store/9rk4x58xkkrvv4si0bhfldgzbj5d9mhp-python3.13-setuptools-80.7.1/lib/python3.13/site-packages/setuptools/build_meta.py", line 331, in get_requires_for_build_wheel
pyyaml>     return self._get_build_requires(config_settings, requirements=[])
pyyaml>            ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pyyaml>   File "/nix/store/9rk4x58xkkrvv4si0bhfldgzbj5d9mhp-python3.13-setuptools-80.7.1/lib/python3.13/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
pyyaml>     self.run_setup()
pyyaml>     ~~~~~~~~~~~~~~^^
pyyaml>   File "/nix/store/9rk4x58xkkrvv4si0bhfldgzbj5d9mhp-python3.13-setuptools-80.7.1/lib/python3.13/site-packages/setuptools/build_meta.py", line 317, in run_setup
pyyaml>     exec(code, locals())
pyyaml>     ~~~~^^^^^^^^^^^^^^^^
pyyaml>   File "<string>", line 289, in <module>
pyyaml>   File "/nix/store/9rk4x58xkkrvv4si0bhfldgzbj5d9mhp-python3.13-setuptools-80.7.1/lib/python3.13/site-packages/setuptools/__init__.py", line 115, in setup
pyyaml>     return distutils.core.setup(**attrs)
pyyaml>            ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
pyyaml>   File "/nix/store/9rk4x58xkkrvv4si0bhfldgzbj5d9mhp-python3.13-setuptools-80.7.1/lib/python3.13/site-packages/setuptools/_distutils/core.py", line 186, in setup
pyyaml>     return run_commands(dist)
pyyaml>   File "/nix/store/9rk4x58xkkrvv4si0bhfldgzbj5d9mhp-python3.13-setuptools-80.7.1/lib/python3.13/site-packages/setuptools/_distutils/core.py", line 202, in run_commands
pyyaml>     dist.run_commands()
pyyaml>     ~~~~~~~~~~~~~~~~~^^
pyyaml>   File "/nix/store/9rk4x58xkkrvv4si0bhfldgzbj5d9mhp-python3.13-setuptools-80.7.1/lib/python3.13/site-packages/setuptools/_distutils/dist.py", line 1002, in run_commands
pyyaml>     self.run_command(cmd)
pyyaml>     ~~~~~~~~~~~~~~~~^^^^^
pyyaml>   File "/nix/store/9rk4x58xkkrvv4si0bhfldgzbj5d9mhp-python3.13-setuptools-80.7.1/lib/python3.13/site-packages/setuptools/dist.py", line 1102, in run_command
pyyaml>     super().run_command(command)
pyyaml>     ~~~~~~~~~~~~~~~~~~~^^^^^^^^^
pyyaml>   File "/nix/store/9rk4x58xkkrvv4si0bhfldgzbj5d9mhp-python3.13-setuptools-80.7.1/lib/python3.13/site-packages/setuptools/_distutils/dist.py", line 1021, in run_command
pyyaml>     cmd_obj.run()
pyyaml>     ~~~~~~~~~~~^^
pyyaml>   File "/nix/store/9rk4x58xkkrvv4si0bhfldgzbj5d9mhp-python3.13-setuptools-80.7.1/lib/python3.13/site-packages/setuptools/command/egg_info.py", line 312, in ru
pyyaml>     self.find_sources()
pyyaml>     ~~~~~~~~~~~~~~~~~^^
pyyaml>   File "/nix/store/9rk4x58xkkrvv4si0bhfldgzbj5d9mhp-python3.13-setuptools-80.7.1/lib/python3.13/site-packages/setuptools/command/egg_info.py", line 320, in find_sources
pyyaml>     mm.run()
pyyaml>     ~~~~~~^^
pyyaml>   File "/nix/store/9rk4x58xkkrvv4si0bhfldgzbj5d9mhp-python3.13-setuptools-80.7.1/lib/python3.13/site-packages/setuptools/command/egg_info.py", line 543, in run
pyyaml>     self.add_defaults()
pyyaml>     ~~~~~~~~~~~~~~~~~^^
pyyaml>   File "/nix/store/9rk4x58xkkrvv4si0bhfldgzbj5d9mhp-python3.13-setuptools-80.7.1/lib/python3.13/site-packages/setuptools/command/egg_info.py", line 581, in add_defaults
pyyaml>     sdist.add_defaults(self)
pyyaml>     ~~~~~~~~~~~~~~~~~~^^^^^^
pyyaml>   File "/nix/store/9rk4x58xkkrvv4si0bhfldgzbj5d9mhp-python3.13-setuptools-80.7.1/lib/python3.13/site-packages/setuptools/command/sdist.py", line 109, in add_defaults
pyyaml>     super().add_defaults()
pyyaml>     ~~~~~~~~~~~~~~~~~~~~^^
pyyaml>   File "/nix/store/9rk4x58xkkrvv4si0bhfldgzbj5d9mhp-python3.13-setuptools-80.7.1/lib/python3.13/site-packages/setuptools/_distutils/command/sdist.py", line 245, in add_defaults
pyyaml>     self._add_defaults_ext()
pyyaml>     ~~~~~~~~~~~~~~~~~~~~~~^^
pyyaml>   File "/nix/store/9rk4x58xkkrvv4si0bhfldgzbj5d9mhp-python3.13-setuptools-80.7.1/lib/python3.13/site-packages/setuptools/_distutils/command/sdist.py", line 330, in _add_defaults_ext
pyyaml>     self.filelist.extend(build_ext.get_source_files())
pyyaml>                          ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
pyyaml>   File "<string>", line 205, in get_source_files
pyyaml>   File "/nix/store/9rk4x58xkkrvv4si0bhfldgzbj5d9mhp-python3.13-setuptools-80.7.1/lib/python3.13/site-packages/setuptools/_distutils/cmd.py", line 131, in __getattr__
pyyaml>     raise AttributeError(attr)
pyyaml> AttributeError: cython_sources
pyyaml>
pyyaml> ERROR Backend subprocess exited when trying to invoke get_requires_for_build_wheel
```
Felt it was worth it more to bump rather than figure out why the entire build process was broken.