### PR TITLE
Fixing older setuptools again

### DIFF
--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -62,7 +62,8 @@ jobs:
             libpython3-all-dev \
             pybuild-plugin-pyproject \
             python3-all \
-            python3-pip
+            python3-pip \
+            python3-tomli
       - name: Import GPG key
         id: gpg_key_import
         uses: crazy-max/ghaction-import-gpg@v6

--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -134,8 +134,12 @@ jobs:
 
       - name: Move Debian packages
         run: mkdir -p artifacts && mv ../*.deb artifacts/
-      - name: Copy Changelog to artifacts
-        run: cp debian/changelog artifacts/changelog
+      - name: Copy Changelog & changes to artifacts
+        run: |
+          cp \
+            debian/changelog \
+            ../*.changes \
+            artifacts/
       - name: Set environment variable for distro
         id: distro_ident
         run: |
@@ -149,6 +153,9 @@ jobs:
       - name: Set environment variable for deb filename
         id: deb_filename_distro
         run: echo DEB_FILENAME_DISTRO=$(basename artifacts/*.deb | sed "s/_all/_all-${{ env.DISTRO_IDENT }}/" ) >> $GITHUB_ENV
+      - name: Set environment variable for deb changes file
+        id: deb_filename_changes_distro
+        run: echo DEB_FILENAME_CHANGES_DISTRO=$(basename artifacts/*.changes | sed "s/_amd64/_amd64-${{ env.DISTRO_IDENT }}/" ) >> $GITHUB_ENV
       - name: Upload Debian package
         uses: actions/upload-artifact@v4
         with:
@@ -164,4 +171,8 @@ jobs:
         with:
           name: artifacts-${{ env.DISTRO_IDENT }}.zip
           path: artifacts/
-
+      - name: Upload Changes
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.DEB_FILENAME_CHANGES_DISTRO }}
+          path: artifacts/*.changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ include-package-data = true
 [tool.setuptools.exclude-package-data]
 "*" = [
   'build',
+  'debian',
 ]
 
 [tool.basedpyright]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "tt-flash"
 version = "3.4.3"
 description = "Utility to flash firmware blobs to tt devices"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 authors = [
   { name = "Daniel Rosen", email = "drosen@tenstorrent.com" }
@@ -16,9 +16,6 @@ classifiers = [
   "Environment :: Console :: Curses",
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3 :: Only",
@@ -37,7 +34,8 @@ dependencies = [
   "importlib-resources >= 1.3.0; python_version < '3.9'",
 ]
 
-optional-dependencies.dev = [
+[project.optional-dependencies]
+dev = [
   "black == 24.10.0; python_version >= '3.9'",
   "black == 24.8.0; python_version == '3.8'",
   "black == 23.3.0; python_version == '3.7'"

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,21 @@ Uses setuptools_scm for dynamic versioning from git tags.
 """
 from setuptools import setup, find_packages
 
+import tomli
+
 if __name__ == "__main__":
+    with open("pyproject.toml", "rb") as f:
+        toml_data = tomli.load(f)
+
     setup(
         # Fallback for older setuptools versions
         name="tt-flash",
-        use_scm_version=True,
+        version=toml_data['project']['version'],
         packages=find_packages(),
         python_requires=">=3.10",
-        setup_requires=['setuptools_scm'],
+        entry_points={
+            'console_scripts': [
+                'tt-flash = tt_flash:main',
+            ]
+        },
     )


### PR DESCRIPTION
Ubuntu 22's older setuptools needs setup.py: fine. However it doesn't read in things like the fact that we have a binary hanging out and need that pulled in, like it does in pyprojects.toml. This sorts that.

It also adds in python3-setuptools-scm so that the warning about versions in gbp goes away (and it does things more correctly)