### PR TITLE
Strictly require latest version of tt-tools-common and pyluwen

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ classifiers = [
 ]
 dependencies = [
   "pyyaml == 6.0.2",
-  'tt_tools_common>=1.4.19',
-  "pyluwen>=0.7.11",
+  'tt_tools_common==1.4.28',
+  "pyluwen==0.7.11",
   "tabulate == 0.9.0",
   "tomli == 2.0.1; python_version < '3.11'",
 


### PR DESCRIPTION
Use absolute versions of `tt-tools-common` and `pyluwen` instead of a range of versions to reduce issues arising from environment inconsistencies.