### PR TITLE
Bump tt-tools-common version to 1.4.29

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
   "pyyaml == 6.0.2",
-  'tt_tools_common==1.4.28',
+  'tt_tools_common==1.4.29',
   "pyluwen==0.7.11",
   "tabulate == 0.9.0",
   "tomli == 2.0.1; python_version < '3.11'",


### PR DESCRIPTION
The tt-tools-common 1.4.29 update includes a fix for erroneous prints of "BH" during reset for WH chips and a change to the reset sequence after secondary bus reset was removed from the tt-kmd ASIC reset code.