### PR TITLE
support manifest versions up to 2.0.0, add validation code for 2.0.0

### DIFF
--- a/tt_flash/main.py
+++ b/tt_flash/main.py
@@ -250,10 +250,6 @@ def main():
             devices = detect_local_chips(ignore_ethernet=True)
 
             print(f"{CConfig.COLOR.GREEN}Stage:{CConfig.COLOR.ENDC} FLASH")
-            if version[0] > 1:
-                raise TTError(
-                    f"Unsupported version ({'.'.join(map(str, version))}) this flash program only supports flashing pre 2.0 packages"
-                )
 
             return flash_chips(
                 config,
@@ -261,6 +257,7 @@ def main():
                 tar,
                 args.force,
                 args.no_reset,
+                version,
                 skip_missing_fw=args.skip_missing_fw,
             )
         else:


### PR DESCRIPTION
Support manifest versions in tt-flash up to 2.0.0, and use more advanced validation functions for manifest versions beyond 2.0.0. For manifest version 1, accept any version to maintain backward compatibility.