### PR TITLE
Add option to use_umd driver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
   "pyyaml == 6.0.2",
   'tt_tools_common == 1.4.31',
   "pyluwen == 0.7.12",
+  # NOTE: To be changed before merged to main.
+  'tt_umd @ git+https://github.com/tenstorrent/tt-umd.git@brosko/more_py_api2',
   "tabulate == 0.9.0",
   "tomli == 2.0.1; python_version < '3.11'",
 

--- a/tt_flash/chip.py
+++ b/tt_flash/chip.py
@@ -14,6 +14,17 @@ from pyluwen import PciChip, Telemetry
 from pyluwen import detect_chips as luwen_detect_chips
 from pyluwen import detect_chips_fallible as luwen_detect_chips_fallible
 
+from tt_umd import (
+    TopologyDiscovery,
+    TTDevice,
+    create_remote_wormhole_tt_device,
+    TelemetryTag,
+    ARCH,
+    wormhole,
+    PCIDevice,
+    SmBusArcTelemetryReader,
+)
+
 from tt_flash import utility
 from tt_flash.error import TTError
 
@@ -113,62 +124,116 @@ def init_fw_defines(chip):
 
 
 class TTChip:
-    def __init__(self, chip: PciChip):
-        self.luwen_chip = chip
-        self.interface_id = chip.pci_interface_id()
+    def __init__(self, chip):
+        self.use_umd = isinstance(chip, TTDevice)
+        if self.use_umd:
+            self.umd_device = chip
+            self.interface_id = chip.get_pci_device().get_device_info().pci_device
+        else:
+            self.luwen_chip = chip
+            self.interface_id = chip.pci_interface_id()
 
         self.fw_defines = init_fw_defines(self)
-
         self.telmetry_cache = None
 
     def reinit(self, callback=None):
-        self.luwen_chip = PciChip(self.interface_id)
-        self.telmetry_cache = None
+        if self.use_umd:
+            self.umd_device = TTDevice.create(self.interface_id)
+            self.umd_device.init_tt_device()
+            self.telmetry_cache = None
+        else:
+            self.luwen_chip = PciChip(self.interface_id)
+            self.telmetry_cache = None
 
-        chip_count = 0
-        block_count = 0
-        last_draw = time.time()
+            chip_count = 0
+            block_count = 0
+            last_draw = time.time()
 
-        def chip_detect_callback(status):
-            nonlocal chip_count, last_draw, block_count
+            def chip_detect_callback(status):
+                nonlocal chip_count, last_draw, block_count
 
-            if status.new_chip():
-                chip_count += 1
-            elif status.correct_down():
-                chip_count -= 1
-            chip_count = max(chip_count, 0)
+                if status.new_chip():
+                    chip_count += 1
+                elif status.correct_down():
+                    chip_count -= 1
+                chip_count = max(chip_count, 0)
 
-            if sys.stdout.isatty():
-                current_time = time.time()
-                if current_time - last_draw > 0.1:
-                    last_draw = current_time
+                if sys.stdout.isatty():
+                    current_time = time.time()
+                    if current_time - last_draw > 0.1:
+                        last_draw = current_time
 
-                    if block_count > 0:
-                        print(f"\033[{block_count}A", end="", flush=True)
-                        print(f"\033[J", end="", flush=True)
+                        if block_count > 0:
+                            print(f"\033[{block_count}A", end="", flush=True)
+                            print(f"\033[J", end="", flush=True)
 
-                    print(f"\rDetected Chips: {chip_count}\n", end="", flush=True)
-                    block_count = 1
+                        print(f"\rDetected Chips: {chip_count}\n", end="", flush=True)
+                        block_count = 1
 
-                    status_string = status.status_string()
-                    if status_string is not None:
-                        for line in status_string.splitlines():
-                            block_count += 1
-                            print(f"\r{line}", flush=True)
+                        status_string = status.status_string()
+                        if status_string is not None:
+                            for line in status_string.splitlines():
+                                block_count += 1
+                                print(f"\r{line}", flush=True)
+                else:
+                    time.sleep(0.01)
+
+            self.luwen_chip.init(
+                callback=chip_detect_callback if callback is None else callback
+            )
+
+    def get_telemetry(self):
+        if self.use_umd:
+            # For UMD, return a telemetry-like object with the required fields
+            arch = self.umd_device.get_arch()
+            
+            # Create the appropriate telemetry reader based on architecture
+            if arch == ARCH.WORMHOLE_B0:
+                telem_reader = SmBusArcTelemetryReader(self.umd_device)
             else:
-                time.sleep(0.01)
-
-        self.luwen_chip.init(
-            callback=chip_detect_callback if callback is None else callback
-        )
-
-    def get_telemetry(self) -> Telemetry:
-        self.telmetry_cache = self.luwen_chip.get_telemetry()
-        return self.telmetry_cache
+                telem_reader = self.umd_device.get_arc_telemetry_reader()
+            
+            # Create a simple telemetry object with the fields we need
+            class UMDTelemetry:
+                def __init__(self, reader, arch):
+                    self.reader = reader
+                    self.arch = arch
+                    # Initialize telemetry fields
+                    self.m3_app_fw_version = None
+                    self.arc1_fw_version = None
+                    self.arc0_fw_version = None
+                    self.asic_location = None
+                    self.fw_bundle_version = None
+                    
+                def get_field(self, tag):
+                    if self.reader.is_entry_available(tag):
+                        return self.reader.read_entry(tag)
+                    return None
+            
+            # Map telemetry fields based on architecture
+            if arch == ARCH.WORMHOLE_B0:
+                telem_obj = UMDTelemetry(telem_reader, arch)
+                # Map wormhole-specific fields
+                telem_obj.m3_app_fw_version = telem_obj.get_field(wormhole.TelemetryTag.M3_APP_FW_VERSION)
+                telem_obj.arc1_fw_version = telem_obj.get_field(wormhole.TelemetryTag.ARC1_FW_VERSION)
+                telem_obj.arc0_fw_version = telem_obj.get_field(wormhole.TelemetryTag.ARC0_FW_VERSION)
+                telem_obj.asic_location = telem_obj.get_field(wormhole.TelemetryTag.ASIC_RO)
+                telem_obj.fw_bundle_version = telem_obj.get_field(wormhole.TelemetryTag.FW_BUNDLE_VERSION)
+            else:
+                telem_obj = UMDTelemetry(telem_reader, arch)
+                # Map universal fields
+                telem_obj.asic_location = telem_obj.get_field(TelemetryTag.HARVESTING_STATE)
+                telem_obj.fw_bundle_version = telem_obj.get_field(TelemetryTag.FLASH_BUNDLE_VERSION)
+            
+            self.telmetry_cache = telem_obj
+            return self.telmetry_cache
+        else:
+            self.telmetry_cache = self.luwen_chip.get_telemetry()
+            return self.telmetry_cache
 
     def get_telemetry_unchanged(self) -> Telemetry:
         if self.telmetry_cache is None:
-            self.telmetry_cache = self.luwen_chip.get_telemetry()
+            self.get_telemetry()
 
         return self.telmetry_cache
 
@@ -202,19 +267,35 @@ class TTChip:
         return telem.asic_location
 
     def board_type(self):
-        return self.luwen_chip.pci_board_type()
+        if self.use_umd:
+            return (self.umd_device.get_board_id() >> 36) & 0xFFFFF
+        else:
+            return self.luwen_chip.pci_board_type()
 
     def spi_write(self, addr: int, data: bytes):
-        self.luwen_chip.spi_write(addr, data)
+        if self.use_umd:
+            self.umd_device.spi_write(addr, data)
+        else:
+            self.luwen_chip.spi_write(addr, data)
 
     def spi_read(self, addr: int, size: int) -> bytes:
-        data = bytearray(size)
-        self.luwen_chip.spi_read(addr, data)
-
-        return bytes(data)
+        if self.use_umd:
+            data = bytearray(size)
+            self.umd_device.spi_read(addr, data)
+            return bytes(data)
+        else:
+            data = bytearray(size)
+            self.luwen_chip.spi_read(addr, data)
+            return bytes(data)
 
     def arc_msg(self, *args, **kwargs):
-        return self.luwen_chip.arc_msg(*args, **kwargs)
+        if self.use_umd:
+            # UMD arc_msg returns a vector where first element is the exit code and the following are the results.
+            # To match the pyluwen format, we return [first result, exit code]
+            result = self.umd_device.arc_msg(*args, **kwargs)
+            return [result[1], result[0]]
+        else:
+            return self.luwen_chip.arc_msg(*args, **kwargs)
 
     @abstractmethod
     def min_fw_version(self):
@@ -247,8 +328,11 @@ class BhChip(TTChip):
             running = (component, major, minor, patch)
 
             # Read SPI FW bundle version
-            cmfwcfg = self.luwen_chip.decode_boot_fs_table("cmfwcfg")
-            temp = cmfwcfg["fw_bundle_version"]
+            if self.use_umd:
+                temp = self.umd_device.get_spi_fw_bundle_version()
+            else:
+                cmfwcfg = self.luwen_chip.decode_boot_fs_table("cmfwcfg")
+                temp = cmfwcfg["fw_bundle_version"]
             patch = temp & 0xFF
             minor = (temp >> 8) & 0xFF
             major = (temp >> 16) & 0xFF
@@ -347,27 +431,40 @@ def detect_local_chips(
             time.sleep(0.01)
 
     output = []
-    for device in luwen_detect_chips_fallible(
-        local_only=True,
-        continue_on_failure=False,
-        callback=chip_detect_callback,
-        noc_safe=ignore_ethernet,
-    ):
-        if not device.have_comms():
-            raise Exception(
-                f"Do not have communication with {device}, you should reset or remove this device from your system before continuing."
-            )
+    if use_umd:
+        pci_ids = PCIDevice.enumerate_devices()
+        for pci_id in pci_ids:
+            umd_device = TTDevice.create(pci_id)
+            umd_device.init_tt_device()
+            arch = umd_device.get_arch()
+            if arch == ARCH.WORMHOLE_B0:
+                output.append(WhChip(umd_device))
+            elif arch == ARCH.BLACKHOLE:
+                output.append(BhChip(umd_device))
+            else:
+                raise ValueError("Did not recognize board")
+    else:
+        for device in luwen_detect_chips_fallible(
+            local_only=True,
+            continue_on_failure=False,
+            callback=chip_detect_callback,
+            noc_safe=ignore_ethernet,
+        ):
+            if not device.have_comms():
+                raise Exception(
+                    f"Do not have communication with {device}, you should reset or remove this device from your system before continuing."
+                )
 
-        device = device.force_upgrade()
+            device = device.force_upgrade()
 
-        if device.as_gs() is not None:
-            output.append(GsChip(device.as_gs()))
-        elif device.as_wh() is not None:
-            output.append(WhChip(device.as_wh()))
-        elif device.as_bh() is not None:
-            output.append(BhChip(device.as_bh()))
-        else:
-            raise ValueError("Did not recognize board")
+            if device.as_gs() is not None:
+                output.append(GsChip(device.as_gs()))
+            elif device.as_wh() is not None:
+                output.append(WhChip(device.as_wh()))
+            elif device.as_bh() is not None:
+                output.append(BhChip(device.as_bh()))
+            else:
+                raise ValueError("Did not recognize board")
 
     if not did_draw:
         print(f"\tDetected Chips: {chip_count}")
@@ -377,14 +474,45 @@ def detect_local_chips(
 
 def detect_chips(local_only: bool = False, use_umd: bool = False) -> list[Union[GsChip, WhChip, BhChip]]:
     output = []
-    for device in luwen_detect_chips(local_only=local_only):
-        if device.as_gs() is not None:
-            output.append(GsChip(device.as_gs()))
-        elif device.as_wh() is not None:
-            output.append(WhChip(device.as_wh()))
-        elif device.as_bh() is not None:
-            output.append(BhChip(device.as_bh()))
-        else:
-            raise ValueError("Did not recognize board")
+    if use_umd:
+        cluster_descriptor = TopologyDiscovery.create_cluster_descriptor()
+        # Note: This will go away soon, the discovery process will return chips.
+        # Note that we have to create mmio chips first, since they are passed to the construction of the remote chips.
+        chips_to_construct = cluster_descriptor.get_chips_local_first(cluster_descriptor.get_all_chips())
+        chip_map = {}
+        for chip in chips_to_construct:
+            if cluster_descriptor.is_chip_mmio_capable(chip):
+                pci_device_num = cluster_descriptor.get_chips_with_mmio()[chip]
+                umd_device = TTDevice.create(pci_device_num)
+                umd_device.init_tt_device()
+                chip_map[chip] = len(output)
+                
+                # Create appropriate TTChip wrapper based on architecture
+                arch = umd_device.get_arch()
+                if arch == ARCH.WORMHOLE_B0:
+                    output.append(WhChip(umd_device))
+                elif arch == ARCH.BLACKHOLE:
+                    output.append(BhChip(umd_device))
+                else:
+                    # For unsupported architectures, create a generic TTChip
+                    output.append(TTChip(umd_device))
+            else:
+                closest_mmio = cluster_descriptor.get_closest_mmio_capable_chip(chip)
+                umd_device = create_remote_wormhole_tt_device(output[chip_map[closest_mmio]].umd_device, cluster_descriptor, chip)
+                umd_device.init_tt_device()
+                chip_map[chip] = len(output)
+                
+                # Remote devices are typically Wormhole
+                output.append(WhChip(umd_device))
+    else:
+        for device in luwen_detect_chips(local_only=local_only):
+            if device.as_gs() is not None:
+                output.append(GsChip(device.as_gs()))
+            elif device.as_wh() is not None:
+                output.append(WhChip(device.as_wh()))
+            elif device.as_bh() is not None:
+                output.append(BhChip(device.as_bh()))
+            else:
+                raise ValueError("Did not recognize board")
 
     return output

--- a/tt_flash/chip.py
+++ b/tt_flash/chip.py
@@ -204,21 +204,6 @@ class TTChip:
     def board_type(self):
         return self.luwen_chip.pci_board_type()
 
-    def axi_write32(self, addr: int, value: int):
-        self.luwen_chip.axi_write32(addr, value)
-
-    def axi_write(self, addr: int, data: bytes):
-        self.luwen_chip.axi_write(addr, data)
-
-    def axi_read32(self, addr: int) -> int:
-        return self.luwen_chip.axi_read32(addr)
-
-    def axi_read(self, addr: int, size: int) -> bytes:
-        data = bytearray(size)
-        self.luwen_chip.axi_read(addr, data)
-
-        return bytes(data)
-
     def spi_write(self, addr: int, data: bytes):
         self.luwen_chip.spi_write(addr, data)
 

--- a/tt_flash/chip.py
+++ b/tt_flash/chip.py
@@ -305,6 +305,7 @@ class GsChip(TTChip):
 
 def detect_local_chips(
     ignore_ethernet: bool = False,
+    use_umd: bool = False,
 ) -> list[Union[GsChip, WhChip, BhChip]]:
     """
     This will create a chip which only gaurentees that you have communication with the chip.
@@ -374,7 +375,7 @@ def detect_local_chips(
     return output
 
 
-def detect_chips(local_only: bool = False) -> list[Union[GsChip, WhChip, BhChip]]:
+def detect_chips(local_only: bool = False, use_umd: bool = False) -> list[Union[GsChip, WhChip, BhChip]]:
     output = []
     for device in luwen_detect_chips(local_only=local_only):
         if device.as_gs() is not None:

--- a/tt_flash/flash.py
+++ b/tt_flash/flash.py
@@ -28,6 +28,7 @@ from tt_tools_common.reset_common.bh_reset import BHChipReset
 from tt_tools_common.reset_common.galaxy_reset import GalaxyReset
 from tt_tools_common.utils_common.tools_utils import detect_chips_with_callback
 from pyluwen import run_wh_ubb_ipmi_reset, run_ubb_wait_for_driver_load
+from tt_umd import WarmReset
 
 
 def rmw_param(
@@ -929,21 +930,30 @@ def flash_chips(
 
                 # All chips are on BH Galaxy UBB
                 if set(to_flash) == {"GALAXY-1"}:
-                    glx_6u_trays_reset()
+                    if use_umd:
+                        WarmReset.ubb_warm_reset()
+                    else:
+                        glx_6u_trays_reset()
                     # All BH chips have now been reset
                     # Don't reset them conventionally
                     needs_reset_bh = []
 
                 if len(needs_reset_wh) > 0:
-                    WHChipReset().full_lds_reset(
-                        pci_interfaces=needs_reset_wh, reset_m3=True
-                    )
+                    if use_umd:
+                        WarmReset.warm_reset(pci_device_ids = needs_reset_wh, reset_m3=True)
+                    else:
+                        WHChipReset().full_lds_reset(
+                            pci_interfaces=needs_reset_wh, reset_m3=True
+                        )
 
                 if len(needs_reset_bh) > 0:
-                    BHChipReset().full_lds_reset(
-                        pci_interfaces=needs_reset_bh, reset_m3=True,
+                    if use_umd:
+                        WarmReset.warm_reset(pci_device_ids = needs_reset_bh, reset_m3=True)
+                    else:
+                        BHChipReset().full_lds_reset(
+                            pci_interfaces=needs_reset_bh, reset_m3=True,
                         m3_delay=m3_delay
-                    )
+                        )
 
                 if len(needs_reset_wh) > 0 or len(needs_reset_bh) > 0:
                     devices = detect_chips(use_umd=use_umd)

--- a/tt_flash/flash.py
+++ b/tt_flash/flash.py
@@ -775,6 +775,7 @@ def flash_chips(
     version: tuple[int, int, int],
     allow_major_downgrades: bool,
     skip_missing_fw: bool = False,
+    use_umd: bool = False,
 ):
     print(f"\t{CConfig.COLOR.GREEN}Sub Stage:{CConfig.COLOR.ENDC} VERIFY")
     if CConfig.is_tty():
@@ -945,7 +946,7 @@ def flash_chips(
                     )
 
                 if len(needs_reset_wh) > 0 or len(needs_reset_bh) > 0:
-                    devices = detect_chips()
+                    devices = detect_chips(use_umd=use_umd)
 
     for idx, chip in enumerate(devices):
         if manifest.bundle_version[0] >= 19 and isinstance(chip, BhChip):

--- a/tt_flash/main.py
+++ b/tt_flash/main.py
@@ -84,6 +84,12 @@ def parse_args():
         default=False,
         action="store_true",
     )
+    parser.add_argument(
+        "--use_umd",
+        default=False,
+        action="store_true",
+        help="Use UMD instead of Luwen driver.",
+    )
 
     subparsers = parser.add_subparsers(title="command", dest="command", required=True)
 
@@ -275,7 +281,7 @@ def main():
             config = load_sys_config(args.sys_config)
 
             print(f"{CConfig.COLOR.GREEN}Stage:{CConfig.COLOR.ENDC} DETECT")
-            devices = detect_local_chips(ignore_ethernet=True)
+            devices = detect_local_chips(ignore_ethernet=True, use_umd=args.use_umd)
 
             print(f"{CConfig.COLOR.GREEN}Stage:{CConfig.COLOR.ENDC} FLASH")
 
@@ -288,6 +294,7 @@ def main():
                 version,
                 args.allow_major_downgrades,
                 skip_missing_fw=args.skip_missing_fw,
+                use_umd=args.use_umd,
             )
         else:
             raise TTError(f"No handler for command {args.command}.")


### PR DESCRIPTION
Related issue: https://github.com/tenstorrent/tt-umd/issues/1433
This PR is an introductory PR to UMD in tt-flash.

The change introduces --use_umd flag, which would turn on using UMD instead of pyluwen for all of the functionality.
tt-umd doesn't support Grayskull so this won't be available with UMD flag.

Changes:
- Consume tt_umd package
- Reset through umd
- spi_read and spi_write through tt_umd
- arc_msg, and bh way of getting fw version through tt_umd

Testing:
Tested on N300 and P150, to be retested on all configurations

There are many relevant UMD PRs to enable this, and this change will switch to main branch once those are merged to UMD main.
