### PR TITLE
Remove all references to Grayskull

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,6 @@ options:
 tt-flash <firmware bundle file path goes here>
 ```
 
-### Grayskull Note
-If you are using a Grayskull-based card, the card itself does not have an on-board reset mechanism. Thus, you will need to reboot for the new firmware to apply.
-
 ### Firmware files
 Firmware files are licensed and distributed independently, as tt-flash solely acts as a utility to update devices with provided firmware images. You can find firmware bundles in a seperate repo at [https://github.com/tenstorrent/tt-firmware](https://github.com/tenstorrent/tt-firmware).
 
@@ -149,6 +146,10 @@ Stage: RESET
  Finishing PCI link reset on BH devices at PCI indices: 0 
 FLASH SUCCESS
 ```
+
+## Supported products
+
+tt-flash can be used to flash Wormhole and Blackhole products. The last version that supported flashing Grayskull products was [v3.4.7](https://github.com/tenstorrent/tt-flash/releases/tag/v3.4.7).
 
 ## License
 

--- a/tt_flash/chip.py
+++ b/tt_flash/chip.py
@@ -28,7 +28,7 @@ class FwVersion:
 
 def get_bundle_version_v1(chip: TTChip) -> FwVersion:
     """
-    Get the currently running bundle version for gs and wh, using a legacy method
+    Get the currently running bundle version for wh, using a legacy method
 
     @param chip
 
@@ -95,12 +95,10 @@ def get_chip_data(chip, file, internal: bool):
     with utility.package_root_path() as path:
         if isinstance(chip, WhChip):
             prefix = "wormhole"
-        elif isinstance(chip, GsChip):
-            prefix = "grayskull"
         elif isinstance(chip, BhChip):
             prefix = "blackhole"
         else:
-            raise TTError("Only support flashing Wh or GS chips")
+            raise TTError("Only support flashing WH or BH chips")
         if internal:
             prefix = f".ignored/{prefix}"
         else:
@@ -307,20 +305,9 @@ class WhChip(TTChip):
         return get_bundle_version_v1(self)
 
 
-class GsChip(TTChip):
-    def min_fw_version(self):
-        return 0x1050000
-
-    def __repr__(self):
-        return f"Grayskull[{self.interface_id}]"
-
-    def get_bundle_version(self) -> FwVersion:
-        return get_bundle_version_v1(self)
-
-
 def detect_local_chips(
     ignore_ethernet: bool = False,
-) -> list[Union[GsChip, WhChip, BhChip]]:
+) -> list[Union[WhChip, BhChip]]:
     """
     This will create a chip which only gaurentees that you have communication with the chip.
     """
@@ -374,9 +361,7 @@ def detect_local_chips(
 
         device = device.force_upgrade()
 
-        if device.as_gs() is not None:
-            output.append(GsChip(device.as_gs()))
-        elif device.as_wh() is not None:
+        if device.as_wh() is not None:
             output.append(WhChip(device.as_wh()))
         elif device.as_bh() is not None:
             output.append(BhChip(device.as_bh()))
@@ -389,12 +374,10 @@ def detect_local_chips(
     return output
 
 
-def detect_chips(local_only: bool = False) -> list[Union[GsChip, WhChip, BhChip]]:
+def detect_chips(local_only: bool = False) -> list[Union[WhChip, BhChip]]:
     output = []
     for device in luwen_detect_chips(local_only=local_only):
-        if device.as_gs() is not None:
-            output.append(GsChip(device.as_gs()))
-        elif device.as_wh() is not None:
+        if device.as_wh() is not None:
             output.append(WhChip(device.as_wh()))
         elif device.as_bh() is not None:
             output.append(BhChip(device.as_bh()))

--- a/tt_flash/flash.py
+++ b/tt_flash/flash.py
@@ -19,7 +19,7 @@ import random
 import tt_flash
 from tt_flash.blackhole import boot_fs_write
 from tt_flash.blackhole import FlashWrite
-from tt_flash.chip import BhChip, TTChip, GsChip, WhChip, detect_chips
+from tt_flash.chip import BhChip, TTChip, WhChip, detect_chips
 from tt_flash.error import TTError
 from tt_flash.utility import change_to_public_name, get_board_type, CConfig
 
@@ -229,7 +229,7 @@ def flash_chip_stage1(
 
     if fw_bundle_version.exception is not None:
         if fw_bundle_version.allow_exception:
-            # Very old gs/wh fw doesn't have support for getting the fw version at all
+            # Very old wh fw doesn't have support for getting the fw version at all
             # so it's safe to assume that we need to update
             if force:
                 print(


### PR DESCRIPTION
Remove GsChip class and support for GS chip detection. As Grayskull has been removed from tt-kmd and luwen, from now on it will not be supported by tt-flash.