### PR TITLE
Add option to use_umd driver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
   "requests >= 2.28.0",
   'tt_tools_common ~= 1.5',
   "pyluwen ~= 0.8.0",
+  "tt_umd == 0.9.5",
   "tabulate == 0.9.0",
   "tomli == 2.0.1; python_version < '3.11'",
 

--- a/tt_flash/chip.py
+++ b/tt_flash/chip.py
@@ -115,15 +115,22 @@ def init_fw_defines(chip):
 
 class TTChip:
     def __init__(self, chip: PciChip):
-        self.luwen_chip = chip
-        self.interface_id = chip.pci_interface_id()
+        self.chip = chip
+        self.interface_id = chip.get_pci_interface_id()
 
+        if self.use_luwen:
+            if chip.as_wh() is not None:
+                self.luwen_chip = chip.as_wh()
+            elif chip.as_bh() is not None:
+                self.luwen_chip = chip.as_bh()
+            else:
+                raise ValueError("Did not recognize board")
         self.fw_defines = init_fw_defines(self)
 
         self.telemetry_cache = None
 
     def reinit(self, callback=None):
-        self.luwen_chip = PciChip(self.interface_id)
+        self.chip = PciChip(self.interface_id)
         self.telemetry_cache = None
 
         chip_count = 0
@@ -159,12 +166,12 @@ class TTChip:
             else:
                 time.sleep(0.01)
 
-        self.luwen_chip.init(
+        self.chip.init(
             callback=chip_detect_callback if callback is None else callback
         )
 
     def get_telemetry(self) -> Telemetry:
-        self.telemetry_cache = self.luwen_chip.get_telemetry()
+        self.telemetry_cache = self.chip.get_telemetry()
         return self.telemetry_cache
 
     def get_telemetry_unchanged(self) -> Telemetry:
@@ -195,23 +202,23 @@ class TTChip:
         return telem.asic_location
 
     def board_type(self):
-        return self.luwen_chip.pci_board_type()
+        return self.chip.pci_board_type()
 
     def board_id(self) -> int:
         return PciChip(self.interface_id).board_id()
 
     def axi_write32(self, addr: int, value: int):
-        self.luwen_chip.axi_write32(addr, value)
+        self.chip.axi_write32(addr, value)
 
     def axi_write(self, addr: int, data: bytes):
-        self.luwen_chip.axi_write(addr, data)
+        self.chip.axi_write(addr, data)
 
     def axi_read32(self, addr: int) -> int:
-        return self.luwen_chip.axi_read32(addr)
+        return self.chip.axi_read32(addr)
 
     def axi_read(self, addr: int, size: int) -> bytes:
         data = bytearray(size)
-        self.luwen_chip.axi_read(addr, data)
+        self.chip.axi_read(addr, data)
 
         return bytes(data)
 
@@ -225,7 +232,7 @@ class TTChip:
         return bytes(data)
 
     def arc_msg(self, *args, **kwargs):
-        return self.luwen_chip.arc_msg(*args, **kwargs)
+        return self.chip.arc_msg(*args, **kwargs)
 
     @abstractmethod
     def min_fw_version(self):
@@ -285,7 +292,7 @@ class BhChip(TTChip):
         except Exception:
             print(f"\rWarning: Unable to retrieve telemetry, reading ASIC location "
                 "via fallback\n", end="", flush=True)
-            gpio_strap = self.luwen_chip.axi_read32(GPIO_STRAP_REG_L)
+            gpio_strap = self.chip.axi_read32(GPIO_STRAP_REG_L)
             # If GPIO6 is high, we are on the left ASIC
             location = (gpio_strap >> 6) & 0x1
 
@@ -419,9 +426,9 @@ def detect_local_chips(
         device = device.force_upgrade()
 
         if device.as_wh() is not None:
-            output.append(WhChip(device.as_wh()))
+            output.append(WhChip(device))
         elif device.as_bh() is not None:
-            output.append(BhChip(device.as_bh()))
+            output.append(BhChip(device))
         else:
             raise ValueError("Did not recognize board")
 
@@ -435,9 +442,9 @@ def detect_chips(local_only: bool = False) -> list[Union[WhChip, BhChip]]:
     output = []
     for device in luwen_detect_chips(local_only=local_only):
         if device.as_wh() is not None:
-            output.append(WhChip(device.as_wh()))
+            output.append(WhChip(device))
         elif device.as_bh() is not None:
-            output.append(BhChip(device.as_bh()))
+            output.append(BhChip(device))
         else:
             raise ValueError("Did not recognize board")
 

--- a/tt_flash/chip.py
+++ b/tt_flash/chip.py
@@ -16,6 +16,8 @@ from pyluwen import detect_chips_fallible as luwen_detect_chips_fallible
 
 from collections import defaultdict
 
+from tt_umd import TTDevice, TopologyDiscoveryOptions, TopologyDiscovery, ARCH, TelemetryTag, SPITTDevice
+
 from tt_flash import utility
 from tt_flash.error import TTError
 from tt_flash.utility import CConfig, get_board_type
@@ -114,9 +116,9 @@ def init_fw_defines(chip):
 
 
 class TTChip:
-    def __init__(self, chip: PciChip):
+    def __init__(self, chip: Union[PciChip, TTDevice]):
+        self.use_luwen = isinstance(chip, PciChip)
         self.chip = chip
-        self.interface_id = chip.get_pci_interface_id()
 
         if self.use_luwen:
             if chip.as_wh() is not None:
@@ -125,12 +127,19 @@ class TTChip:
                 self.luwen_chip = chip.as_bh()
             else:
                 raise ValueError("Did not recognize board")
+
+            self.interface_id = self.luwen_chip.pci_interface_id()
+        else:
+            self.interface_id = chip.get_pci_interface_id()
         self.fw_defines = init_fw_defines(self)
 
         self.telemetry_cache = None
 
     def reinit(self, callback=None):
-        self.chip = PciChip(self.interface_id)
+        if self.use_luwen:
+            self.chip = PciChip(self.interface_id)
+        else:
+            self.chip = TTDevice.create(self.interface_id)
         self.telemetry_cache = None
 
         chip_count = 0
@@ -166,12 +175,41 @@ class TTChip:
             else:
                 time.sleep(0.01)
 
-        self.chip.init(
-            callback=chip_detect_callback if callback is None else callback
-        )
+        if self.use_luwen:
+            self.chip.init(
+                callback=chip_detect_callback if callback is None else callback
+            )
+        else:
+            # Unfortunately the current TTDevice API does not allow for a callback during init.
+            self.chip.init_tt_device()
 
-    def get_telemetry(self) -> Telemetry:
-        self.telemetry_cache = self.chip.get_telemetry()
+    def get_telemetry(self):
+        if self.use_luwen:
+            self.telemetry_cache = self.chip.get_telemetry()
+            return self.telemetry_cache
+
+        # Create a simple telemetry object with the fields we need
+        class UMDTelemetry:
+            def __init__(self, reader, arch):
+                self.reader = reader
+                self.arch = arch
+                # Initialize telemetry fields
+                self.m3_app_fw_version = None
+                self.asic_location = None
+                self.fw_bundle_version = None
+                
+            def get_field(self, tag):
+                if self.reader.is_entry_available(tag):
+                    return self.reader.read_entry(tag)
+                return None
+            
+        telem_obj = UMDTelemetry(self.chip.get_arc_telemetry_reader(), self.chip.get_arch())
+
+        telem_obj.m3_app_fw_version = telem_obj.get_field(TelemetryTag.DM_APP_FW_VERSION)
+        telem_obj.asic_location = telem_obj.get_field(TelemetryTag.ASIC_LOCATION)
+        telem_obj.fw_bundle_version = telem_obj.get_field(TelemetryTag.FLASH_BUNDLE_VERSION)
+
+        self.telemetry_cache = telem_obj
         return self.telemetry_cache
 
     def get_telemetry_unchanged(self) -> Telemetry:
@@ -202,10 +240,18 @@ class TTChip:
         return telem.asic_location
 
     def board_type(self):
-        return self.chip.pci_board_type()
+        if self.use_luwen:
+            return self.chip.pci_board_type()
+        else:
+            # UMD's TTDevice has no pci_board_type(); the UPI lives in bits 36-55
+            # of the board id, which is what get_board_type(from_type=True) expects.
+            return (self.chip.get_board_id() >> 36) & 0xFFFFF
 
     def board_id(self) -> int:
-        return PciChip(self.interface_id).board_id()
+        if self.use_luwen:
+            return PciChip(self.interface_id).board_id()
+        else:
+            return self.chip.get_board_id()
 
     def axi_write32(self, addr: int, value: int):
         self.chip.axi_write32(addr, value)
@@ -223,16 +269,28 @@ class TTChip:
         return bytes(data)
 
     def spi_write(self, addr: int, data: bytes):
-        self.luwen_chip.spi_write(addr, data)
+        if self.use_luwen:
+            self.luwen_chip.spi_write(addr, data)
+        else:
+            chip_spi = SPITTDevice.create(self.chip)
+            chip_spi.write(addr, data)
 
     def spi_read(self, addr: int, size: int) -> bytes:
         data = bytearray(size)
-        self.luwen_chip.spi_read(addr, data)
+        if self.use_luwen:
+            self.luwen_chip.spi_read(addr, data)
+        else:
+            chip_spi = SPITTDevice.create(self.chip)
+            chip_spi.read(addr, data)
 
         return bytes(data)
 
     def arc_msg(self, *args, **kwargs):
-        return self.chip.arc_msg(*args, **kwargs)
+        if self.use_luwen:
+            return self.chip.arc_msg(*args, **kwargs)
+        else:
+            # Note: UMD returns exit code as the first item, so eat this up and return the rest of the data as the response.
+            return self.chip.arc_msg(*args, **kwargs)[1:]
 
     @abstractmethod
     def min_fw_version(self):
@@ -265,8 +323,12 @@ class BhChip(TTChip):
             running = (component, major, minor, patch)
 
             # Read SPI FW bundle version
-            cmfwcfg = self.luwen_chip.decode_boot_fs_table("cmfwcfg")
-            temp = cmfwcfg["fw_bundle_version"]
+            if self.use_luwen:
+                cmfwcfg = self.luwen_chip.decode_boot_fs_table("cmfwcfg")
+                temp = cmfwcfg["fw_bundle_version"]
+            else:
+                chip_spi = SPITTDevice.create(self.chip)
+                temp = chip_spi.get_spi_fw_bundle_version()
             patch = temp & 0xFF
             minor = (temp >> 8) & 0xFF
             major = (temp >> 16) & 0xFF
@@ -371,6 +433,7 @@ def validate_p300_can_be_flashed(
 
 def detect_local_chips(
     ignore_ethernet: bool = False,
+    use_luwen: bool = True,
 ) -> list[Union[WhChip, BhChip]]:
     """
     This will create a chip which only guarantees that you have communication with the chip.
@@ -412,18 +475,27 @@ def detect_local_chips(
             time.sleep(0.01)
 
     output = []
-    for device in luwen_detect_chips_fallible(
-        local_only=True,
-        continue_on_failure=False,
-        callback=chip_detect_callback,
-        noc_safe=ignore_ethernet,
-    ):
-        if not device.have_comms():
-            raise Exception(
-                f"Do not have communication with {device}, you should reset or remove this device from your system before continuing."
-            )
+    devices = []
+    if use_luwen:
+        devices = dict(enumerate(luwen_detect_chips_fallible(
+            local_only=True,
+            continue_on_failure=False,
+            callback=chip_detect_callback,
+            noc_safe=ignore_ethernet,
+        )))
+    else:
+        options = TopologyDiscoveryOptions()
+        options.wait_on_ethernet_link_training = not ignore_ethernet
+        options.discover_remote_devices = not ignore_ethernet
+        _, devices = TopologyDiscovery.discover(options)
+    for idx, device in devices.items():
+        if use_luwen:
+            if not device.have_comms():
+                raise Exception(
+                    f"Do not have communication with {device}, you should reset or remove this device from your system before continuing."
+                )
 
-        device = device.force_upgrade()
+            device = device.force_upgrade()
 
         if device.as_wh() is not None:
             output.append(WhChip(device))
@@ -438,9 +510,18 @@ def detect_local_chips(
     return output
 
 
-def detect_chips(local_only: bool = False) -> list[Union[WhChip, BhChip]]:
+def detect_chips(local_only: bool = False, use_luwen: bool = False) -> list[Union[WhChip, BhChip]]:
     output = []
-    for device in luwen_detect_chips(local_only=local_only):
+
+    if use_luwen:
+        devices = dict(enumerate(luwen_detect_chips(local_only=local_only)))
+    else:
+        options = TopologyDiscoveryOptions()
+        options.wait_on_ethernet_link_training = not local_only
+        options.discover_remote_devices = not local_only
+        _, devices = TopologyDiscovery.discover(options)
+    
+    for _, device in devices.items():
         if device.as_wh() is not None:
             output.append(WhChip(device))
         elif device.as_bh() is not None:

--- a/tt_flash/chip.py
+++ b/tt_flash/chip.py
@@ -120,11 +120,11 @@ class TTChip:
 
         self.fw_defines = init_fw_defines(self)
 
-        self.telmetry_cache = None
+        self.telemetry_cache = None
 
     def reinit(self, callback=None):
         self.luwen_chip = PciChip(self.interface_id)
-        self.telmetry_cache = None
+        self.telemetry_cache = None
 
         chip_count = 0
         block_count = 0
@@ -164,14 +164,14 @@ class TTChip:
         )
 
     def get_telemetry(self) -> Telemetry:
-        self.telmetry_cache = self.luwen_chip.get_telemetry()
-        return self.telmetry_cache
+        self.telemetry_cache = self.luwen_chip.get_telemetry()
+        return self.telemetry_cache
 
     def get_telemetry_unchanged(self) -> Telemetry:
-        if self.telmetry_cache is None:
-            self.telmetry_cache = self.luwen_chip.get_telemetry()
+        if self.telemetry_cache is None:
+            return self.get_telemetry()
 
-        return self.telmetry_cache
+        return self.telemetry_cache
 
     def __vnum_to_version(self, version: int) -> tuple[int, int, int, int]:
         return (

--- a/tt_flash/chip.py
+++ b/tt_flash/chip.py
@@ -185,14 +185,6 @@ class TTChip:
         telem = self.get_telemetry_unchanged()
         return self.__vnum_to_version(telem.m3_app_fw_version)
 
-    def smbus_fw_version(self):
-        telem = self.get_telemetry_unchanged()
-        return self.__vnum_to_version(telem.arc1_fw_version)
-
-    def arc_l2_fw_version(self):
-        telem = self.get_telemetry_unchanged()
-        return self.__vnum_to_version(telem.arc0_fw_version)
-
     def get_asic_location(self) -> int:
         """
         Get the location of the ASIC on the chip for p300

--- a/tt_flash/flash.py
+++ b/tt_flash/flash.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum, auto
+import datetime
 import json
 import tarfile
 import time
@@ -28,6 +29,7 @@ from tt_tools_common.reset_common.chip_reset import ChipReset, IoctlResetFlags
 from tt_tools_common.utils_common.tools_utils import detect_chips_with_callback
 from pyluwen import run_wh_ubb_ipmi_reset, run_ubb_wait_for_driver_load, pci_scan, PciChip
 
+from tt_umd import WarmReset
 
 def normalize_fw_version(version: Optional[tuple[int, int, int, int]]) -> Optional[tuple[int, int, int, int]]:
     """
@@ -665,7 +667,8 @@ def reset_devices(
     needs_reset_wh: list[int],
     needs_reset_bh: list[int],
     m3_delay: int,
-    boardnames: list[str]
+    boardnames: list[str],
+    use_luwen: bool = False
 ) -> Optional[list[TTChip]]:
     """
     Reset all devices that need to be reset based on lists of pci IDs to reset
@@ -685,16 +688,25 @@ def reset_devices(
         
         # All chips are on WH Galaxy UBB
         elif set(boardnames) == {"WH_UBB"}:
-            glx_6u_trays_reset()
+            if use_luwen:
+                glx_6u_trays_reset()
+            else:
+                WarmReset.ubb_warm_reset()
             needs_reset_wh = [] # Don't reset WH chips conventionally
 
         if len(needs_reset_wh) > 0:
-            WHChipReset().full_lds_reset(pci_interfaces=needs_reset_wh, reset_m3=True)
+            if use_luwen:
+                WHChipReset().full_lds_reset(pci_interfaces=needs_reset_wh, reset_m3=True)
+            else:
+                WarmReset.warm_reset(pci_device_ids = needs_reset_wh, reset_m3=True)
 
         if len(needs_reset_bh) > 0:
-            BHChipReset().full_lds_reset(
-                pci_interfaces=needs_reset_bh, reset_m3=True, m3_delay=m3_delay
-            )
+            if use_luwen:
+                BHChipReset().full_lds_reset(
+                    pci_interfaces=needs_reset_bh, reset_m3=True, m3_delay=m3_delay
+                )
+            else:
+                WarmReset.warm_reset(pci_device_ids = needs_reset_bh, reset_m3=True, m3_delay_s=datetime.timedelta(seconds=m3_delay))
 
         devices = detect_chips()
 

--- a/tt_flash/flash.py
+++ b/tt_flash/flash.py
@@ -553,9 +553,9 @@ def flash_chip(
     # Need to re-open chip in this process because chip object can't be pickled
     pci_chip = PciChip(interface_id)
     if pci_chip.as_bh() is not None:
-        dev = BhChip(pci_chip.as_bh())
+        dev = BhChip(pci_chip)
     elif pci_chip.as_wh() is not None:
-        dev = WhChip(pci_chip.as_wh())
+        dev = WhChip(pci_chip)
     elif skip_missing_fw:
         debug_messages.append(f"{CConfig.COLOR.YELLOW}Chip type not supported, skipping flash...{CConfig.COLOR.ENDC}")
         return FlashResult(debug_messages=debug_messages)

--- a/tt_flash/flash.py
+++ b/tt_flash/flash.py
@@ -29,7 +29,7 @@ from tt_tools_common.reset_common.chip_reset import ChipReset, IoctlResetFlags
 from tt_tools_common.utils_common.tools_utils import detect_chips_with_callback
 from pyluwen import run_wh_ubb_ipmi_reset, run_ubb_wait_for_driver_load, pci_scan, PciChip
 
-from tt_umd import WarmReset
+from tt_umd import TTDevice, WarmReset
 
 def normalize_fw_version(version: Optional[tuple[int, int, int, int]]) -> Optional[tuple[int, int, int, int]]:
     """
@@ -543,6 +543,7 @@ def flash_chip(
     force: bool,
     allow_major_downgrades: bool,
     skip_missing_fw: bool = False,
+    use_luwen: bool = False,
 ) -> FlashResult:
     """
     Flash firmware to a single chip. This function is process-safe and is intended to be called by
@@ -553,7 +554,12 @@ def flash_chip(
     debug_messages = []
 
     # Need to re-open chip in this process because chip object can't be pickled
-    pci_chip = PciChip(interface_id)
+    if use_luwen:
+        pci_chip = PciChip(interface_id)
+    else:
+        pci_chip = TTDevice.create(interface_id)
+        pci_chip.init_tt_device()
+        
     if pci_chip.as_bh() is not None:
         dev = BhChip(pci_chip)
     elif pci_chip.as_wh() is not None:
@@ -708,7 +714,7 @@ def reset_devices(
             else:
                 WarmReset.warm_reset(pci_device_ids = needs_reset_bh, reset_m3=True, m3_delay_s=datetime.timedelta(seconds=m3_delay))
 
-        devices = detect_chips()
+        devices = detect_chips(use_luwen=use_luwen)
 
     return devices
 

--- a/tt_flash/main.py
+++ b/tt_flash/main.py
@@ -135,6 +135,12 @@ def parse_args():
     flash.add_argument(
         "--allow-major-downgrades", default=False, action="store_true", help="Allow major version downgrades"
     )
+    flash.add_argument(
+        "--use_luwen",
+        default=False,
+        action="store_true",
+        help="Use deprecated Luwen driver instead of UMD (default).",
+    )
 
     verify = subparsers.add_parser(
         "verify",
@@ -331,7 +337,7 @@ def main():
                     # Remove device object so we don't hold a file descriptor
                     # open across reset, as KMD will deny access to it after reset
                     del devices
-                    devices = reset_devices(needs_reset_wh, needs_reset_bh, m3_delay, boardnames)
+                    devices = reset_devices(needs_reset_wh, needs_reset_bh, m3_delay, boardnames, args.use_luwen)
 
             if devices is not None:
                 post_flash_check(devices, manifest)

--- a/tt_flash/main.py
+++ b/tt_flash/main.py
@@ -254,7 +254,7 @@ def main():
                 sys.exit(1)
 
             print(f"{CConfig.COLOR.GREEN}Stage:{CConfig.COLOR.ENDC} DETECT")
-            devices = detect_local_chips(ignore_ethernet=True)
+            devices = detect_local_chips(ignore_ethernet=True, use_luwen=args.use_luwen)
 
             devices, p300_incomplete = validate_p300_can_be_flashed(devices)
 
@@ -298,7 +298,7 @@ def main():
             try:
                 # Run flash operations
                 flash_chip_args = [
-                    (dev.interface_id, fwbundle, manifest, args.force, args.allow_major_downgrades, args.skip_missing_fw)
+                    (dev.interface_id, fwbundle, manifest, args.force, args.allow_major_downgrades, args.skip_missing_fw, args.use_luwen)
                     for dev in devices
                 ]
                 with Pool(initializer=pool_worker_init) as p:

--- a/tt_flash/wormhole.py
+++ b/tt_flash/wormhole.py
@@ -220,24 +220,16 @@ def check_wh_can_reset(
         debug_messages.append(
             "\t\t\tBoard will require reset to complete update, checking if an automatic reset is possible"
         )
-        can_reset = False
-
         try:
-            can_reset = (
-                chip.m3_fw_app_version() >= (5, 5, 0, 0)
-                and chip.arc_l2_fw_version() >= (2, 0xC, 0, 0)
-                and chip.smbus_fw_version() >= (2, 0xC, 0, 0)
+            debug_messages.append(
+                f"\t\t\t\t{CConfig.COLOR.GREEN}Success:{CConfig.COLOR.ENDC} Board can be auto reset; will be triggered if the flash is successful"
             )
-            if can_reset:
-                debug_messages.append(
-                    f"\t\t\t\t{CConfig.COLOR.GREEN}Success:{CConfig.COLOR.ENDC} Board can be auto reset; will be triggered if the flash is successful"
-                )
+            return True
         except Exception as e:
             debug_messages.append(
                 f"\t\t\t\t{CConfig.COLOR.YELLOW}Fail:{CConfig.COLOR.ENDC} Board cannot be auto reset: Failed to get the current firmware versions. This won't stop the flash, but will require manual reset"
             )
-            can_reset = False
-        return can_reset
+            return False
     elif boardname == "WH_UBB":
         return True
     else:


### PR DESCRIPTION
A rework of https://github.com/tenstorrent/tt-flash/pull/94

Related issue: https://github.com/tenstorrent/tt-umd/issues/1433
This PR is an introductory PR to UMD in tt-flash.

The change introduces usage of UMD, but keeps an option to still use luwen through --use_luwen flag.

Commits:

Minor telemetry fix, reuse the same implementation
Remove support for FW < 5.5.0 which didn't support reset
Fix passing PciChip to TTChip
Add umd python package
Use UMD for reset, discovery and chip operations
Testing:
Tested on N300 and P150, to be retested on all configurations

There were many relevant UMD PRs to enable this. There is another pending PR with minor API py changes.