### PR TITLE
feat(bh): preserve ccfgovr table across flashes

### DIFF
--- a/tests/test_tag_handlers.py
+++ b/tests/test_tag_handlers.py
@@ -13,7 +13,13 @@ import tarfile
 import pytest
 
 from tt_flash import boot_fs
-from tt_flash.blackhole import writeback_boardcfg, parse_writes_from_image, FlashWrite
+from tt_flash.blackhole import (
+    CCFGOVR_TAGS,
+    FlashWrite,
+    parse_writes_from_image,
+    skip_ccfgovr,
+    writeback_boardcfg,
+)
 from tt_flash.chip import BhChip, TTChip
 from tt_flash.utility import get_board_type
 
@@ -103,6 +109,46 @@ class TestTagHandlers:
             assert (
                 new_boardcfg_data == current_boardcfg_data
             ), "boardcfg data not preserved"
+
+    def test_skip_ccfgovr_drops_bank_writes(
+        self, bh_chips: list[BhChip], fwbundle_path: str
+    ):
+        """
+        BH Only.
+        skip_ccfgovr should remove the body FlashWrite for each ccfgovr bank
+        present in the image while leaving the FD entries in place.
+        """
+        for bh_chip in bh_chips:
+            writes = bh_load_flash_writes_from_fwbundle(bh_chip, fwbundle_path)
+
+            bank_addrs = {}
+            for tag in CCFGOVR_TAGS:
+                for write in writes:
+                    fd = boot_fs.read_tag(
+                        lambda addr, size: write.write[addr : addr + size], tag
+                    )
+                    if fd is not None:
+                        bank_addrs[tag] = fd[1].spi_addr
+                        break
+
+            if not bank_addrs:
+                pytest.skip("fwbundle has no ccfgovr banks for this board")
+
+            writes = skip_ccfgovr(bh_chip, writes)
+
+            for tag, addr in bank_addrs.items():
+                assert not any(w.offset == addr for w in writes), (
+                    f"skip_ccfgovr left a body write for {tag} at 0x{addr:x}"
+                )
+                # FD entry must still be locatable in the remaining writes.
+                found_fd = False
+                for write in writes:
+                    if boot_fs.read_tag(
+                        lambda a, s: write.write[a : a + s], tag
+                    ) is not None:
+                        found_fd = True
+                        break
+                assert found_fd, f"skip_ccfgovr removed the {tag} FD entry"
 
     # TODO: test if boardcfg is a decodable read-only protobuf?
 

--- a/tt_flash/blackhole.py
+++ b/tt_flash/blackhole.py
@@ -107,6 +107,43 @@ def writeback_boardcfg(chip: BhChip, writes: list[FlashWrite]) -> list[FlashWrit
     return writes
 
 
+CCFGOVR_TAGS = ("ccfgovra", "ccfgovrb")
+
+
+def skip_ccfgovr(chip: BhChip, writes: list[FlashWrite]) -> list[FlashWrite]:
+    """
+    Drop the body writes for the ccfgovra and ccfgovrb banks so the on-chip
+    partitions are preserved across firmware updates.
+
+    These banks hold a CRC-protected protobuf body that the firmware decodes
+    on top of cmfwcfg at boot. They are field-updated by tt-mod (and friends),
+    which rewrites the body but cannot update the FD's data_crc — the FD lives
+    in the descriptor region, a different physical sector. The firmware
+    therefore ignores data_crc for these tags and validates each bank via the
+    cksum word stored inside its header. tt-flash mirrors that contract: we
+    leave the FD entries (and their stale data_crc values) alone, and we don't
+    overwrite the bank bodies. On a chip that has never seen these partitions,
+    the on-chip bytes are 0xFF and the firmware falls back to cmfwcfg, which
+    is the documented first-boot behaviour.
+    """
+    for tag in CCFGOVR_TAGS:
+        fd_to_flash = None
+        for write in writes:
+            fd_to_flash = boot_fs.read_tag(
+                lambda addr, size: write.write[addr : addr + size], tag
+            )
+            if fd_to_flash is not None:
+                break
+
+        if fd_to_flash is None:
+            continue
+
+        bank_addr = fd_to_flash[1].spi_addr
+        writes = [w for w in writes if w.offset != bank_addr]
+
+    return writes
+
+
 TAG_HANDLERS = {"write-boardcfg": writeback_boardcfg}
 
 
@@ -182,5 +219,12 @@ def boot_fs_write(
 
     for handler in param_handlers:
         writes = handler(chip, writes)
+
+    # Always preserve any on-chip ccfgovr banks: the image ships an empty
+    # bank but the on-chip bytes may have been mutated in the field by
+    # tt-mod, and the firmware decodes them on top of cmfwcfg at boot.
+    # Triggered by the FD entries being present in the image, not by a
+    # mask.json tag, so older bundles without ccfgovr remain a no-op.
+    writes = skip_ccfgovr(chip, writes)
 
     return writes

--- a/tt_flash/boot_fs.py
+++ b/tt_flash/boot_fs.py
@@ -127,8 +127,11 @@ class tt_boot_fs_fd(ExtendedStructure):
         return output
 
 
-def read_fd(reader, addr: int) -> tt_boot_fs_fd:
-    fd = reader(addr, ctypes.sizeof(tt_boot_fs_fd))
+def read_fd(reader, addr: int) -> Optional[tt_boot_fs_fd]:
+    fd_size = ctypes.sizeof(tt_boot_fs_fd)
+    fd = reader(addr, fd_size)
+    if len(fd) < fd_size:
+        return None
     return tt_boot_fs_fd.from_buffer_copy(fd)
 
 
@@ -139,7 +142,7 @@ def read_tag(
     while True:
         fd = read_fd(reader, curr_addr)
 
-        if fd.flags.f.invalid != 0:
+        if fd is None or fd.flags.f.invalid != 0:
             return None
 
         if fd.image_tag_str() == tag:


### PR DESCRIPTION
The new ccfgovr SPI partitions added by tt-system-firmware are
field-updatable by tt-mod and are validated by firmware via the cksum in
each bank header (not the FD data_crc). Dropping the body writes for
these banks during flash preserves any user-set overrides while leaving
the image's empty-bank fallback intact for first-boot.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
