### PR TITLE
Add support for Orion SLT

### DIFF
--- a/tt_flash/utility.py
+++ b/tt_flash/utility.py
@@ -80,6 +80,8 @@ def get_board_type(board_id: int, from_type: bool = False) -> Optional[str]:
         return "WH_UBB"
     elif upi == 0x36:
         return "P100-1"
+    elif upi == 0x37:
+        return "ORION_SLT-1"
     elif upi == 0x40:
         return "P150A-1"
     elif upi == 0x41:
@@ -111,6 +113,7 @@ def change_to_public_name(codename: str) -> str:
         "NEBULA_X2": "n300",
         "WH_UBB": "Galaxy Wormhole",
         "P100-1": "p100",
+        "ORION_SLT-1": "orion_slt",
         "P150A-1": "p150a",
         "P150B-1": "p150b",
         "P150C-1": "p150c",


### PR DESCRIPTION
Tested on Orion SLT,

Before the change,
```
-- west flash: using runner tt_flash
Stage: SETUP
Stage: DETECT
Stage: FLASH
	Sub Stage: VERIFY
		Verifying fw-package can be flashed: complete
		Flashing devices, this might take a minute... ✓
Error: Did not recognize board type for Blackhole[0]
FATAL ERROR: command exited with status 1: /home/jenkinsad/tt-system-firmware-work/.venv/bin/tt-flash flash /home/jenkinsad/tt-system-firmware-work/tt-system-firmware/build/update.fwbundle --force
```

After the change,

```
-- west flash: using runner tt_flash
Stage: SETUP
Stage: DETECT
Stage: FLASH
	Sub Stage: VERIFY
		Verifying fw-package can be flashed: complete
		Flashing devices, this might take a minute... ✓
		Verifying Blackhole[0] can be flashed... SUCCESS
	Stage: FLASH
		Sub Stage FLASH Step 1: Blackhole[0]
			ROM version is: (19, 10, 99, 0). tt-flash version is: (19, 11, 99, 0)
			Forced ROM update requested. ROM will now be updated.
		Sub Stage FLASH Step 2: Blackhole[0] {orion_slt}
			Writing new firmware... SUCCESS
			Firmware verification... SUCCESS
Stage: RESET
 Starting reset on devices at PCI indices: 0
 Waiting for 20 seconds for potential hotplug removal.
 Waiting for devices to reappear on pci bus...
 Reset successfully completed for device at PCI index 0.
 Finishing reset on devices at PCI indices: 0
FLASH SUCCESS
```