### PR TITLE
Static fw table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- `flash`: `--update-boot-images` writes the bundle's bootloader and recovery
+  images even when the board already holds the same ones, for provisioning and
+  board recovery.
+
+### Changed
+
+- `flash`: the boot-critical images (`cmfw`, `safeimg`, `safetail`, `failover`)
+  and the ROM and failover descriptor tables are now left alone when the board
+  already holds the same content, so a routine update no longer opens a
+  power-loss window on the path by which a board boots at all. Whether an image
+  is the same is decided by the SHA-256 and key hash that `imgtool` records in
+  it, because signing is not reproducible: two builds of the same source differ
+  only in the trailing signature. Pass `--update-boot-images` for the previous
+  behaviour of writing them unconditionally.
+
+### Fixed
+
+- `flash`: a P300 chip running recovery firmware publishes no board id, so the
+  pairing check filed it as not a P300, left its sibling alone in a group of
+  one, and dropped both halves of the card from the flash list -- refusing the
+  board because of the chip that most needed flashing. Such a chip is now
+  identified by its PCI subsystem id, which carries the same UPI whatever the
+  chip is running.
+- `boot_fs`: `tt_boot_fs_fd.image_tag_str()` compared each `c_uint8` tag byte
+  against the string `"\0"`, which never matched, so NUL padding was included in
+  the decoded tag. Tags shorter than 8 bytes (e.g. `cmfw`) now compare correctly.
+  This makes `read_tag` robust across the multi-table boot filesystem layout
+  (ROM, failover, and mutable descriptor tables).
+
 ## 3.4.0 - 30/07/25
 
 - Bump pyyaml 6.0.1 -> 6.0.2

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ command:
 ```
 $ tt-flash flash -h
 
-usage: tt-flash flash [-h] [--sys-config SYS_CONFIG] [--fw-tar FW_TAR] [--skip-missing-fw] [--force] [--no-reset] [fwbundle]
+usage: tt-flash flash [-h] [--sys-config SYS_CONFIG] [--fw-tar FW_TAR] [--skip-missing-fw] [--force] [--no-reset] [--allow-major-downgrades] [--update-boot-images] [fwbundle]
 
 positional arguments:
   fwbundle              Path to the firmware bundle
@@ -96,6 +96,9 @@ options:
   --skip-missing-fw     If the fw packages doesn't contain the fw for a detected board, continue flashing
   --force               Force update the ROM
   --no-reset            Do not reset devices at the end of flash
+  --allow-major-downgrades
+                        Allow major version downgrades
+  --update-boot-images  Write the bundle's bootloader and recovery images even if the board already holds the same ones. They are left alone by default so that a power loss during an update cannot corrupt the board's boot path
 ```
 
 ## Typical usage

--- a/tests/test_boot_critical.py
+++ b/tests/test_boot_critical.py
@@ -1,0 +1,540 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for skip_boot_critical. These do not require hardware: a small
+in-memory flash and a fake chip stand in for a real BH device.
+
+Usage:
+    pytest tests/test_boot_critical.py -v
+"""
+
+import ctypes
+import struct
+from typing import Optional
+
+from tt_flash import boot_fs
+from tt_flash.blackhole import (
+    BOOT_CRITICAL_TAGS,
+    MCUBOOT_IMAGE_MAGIC,
+    MCUBOOT_TLV_INFO,
+    MCUBOOT_TLV_KEYHASH,
+    MCUBOOT_TLV_SHA256,
+    FlashWrite,
+    calculate_checksum,
+    skip_boot_critical,
+    skip_unchanged_static_regions,
+)
+
+MCUBOOT_HDR_SIZE = 32
+TLV_INFO_MAGIC = 0x6907
+TLV_RSA2048_PSS = 0x20
+
+FD_SIZE = ctypes.sizeof(boot_fs.tt_boot_fs_fd)
+INVALID_FD = b"\xff" * FD_SIZE
+
+# Fixed flash layout used by these tests. cmfw/safeimg/safetail live in the ROM
+# table at 0x0; failover lives in the failover table at 0x4000.
+ROM_HEAD = boot_fs.TT_BOOT_FS_FD_HEAD_ADDR
+FAILOVER_HEAD = boot_fs.TT_BOOT_FS_FAILOVER_HEAD_ADDR
+
+IMAGE_ADDRS = {
+    "cmfw": 0x14000,
+    "safeimg": 0x34000,
+    "safetail": 0xB3000,
+    "failover": 0xB4000,
+}
+
+# The SPI RX training word the bootfs carries at 0x13FFC, directly ahead of
+# MCUBoot at 0x14000. The bundle emits contiguous flash as a single write, so
+# these two arrive merged and cmfw's body does not start at its descriptor's
+# spi_addr. Modelled here because a fixture that gives cmfw its own write hides
+# that, and with it the only case where the two differ.
+SPI_RX_ADDR = 0x13FFC
+SPI_RX_VALUE = (0xA5A55A5A).to_bytes(4, "little")
+
+
+class FakeChip:
+    """Minimal stand-in exposing just spi_read over an in-memory flash."""
+
+    def __init__(self, flash: bytes):
+        self.flash = bytearray(flash)
+
+    def spi_read(self, addr: int, size: int) -> bytes:
+        return bytes(self.flash[addr : addr + size])
+
+    def apply(self, writes: list[FlashWrite]) -> None:
+        """Carry out a write plan, so the resulting flash can be inspected."""
+        for write in writes:
+            self.flash[write.offset : write.offset + len(write.write)] = write.write
+
+
+def make_fd(
+    tag: str,
+    spi_addr: int,
+    data: bytes,
+    executable: bool = False,
+    copy_dest: int = 0,
+) -> bytes:
+    fd = boot_fs.tt_boot_fs_fd()
+    fd.spi_addr = spi_addr
+    fd.copy_dest = copy_dest
+    fd.flags.f.image_size = len(data)
+    fd.flags.f.invalid = 0
+    fd.flags.f.executable = 1 if executable else 0
+    fd.data_crc = calculate_checksum(data)
+    for i, b in enumerate(tag.encode()):
+        fd.image_tag[i] = b
+    return bytes(fd)
+
+
+def make_failover_fd(data: bytes, executable: bool = True) -> bytes:
+    """
+    A failover descriptor as tt_boot_fs.py mkfs actually emits it: at the fixed
+    failover address with a blank image_tag (the SMC ROM identifies the slot by
+    address, not tag), and by default marked executable so the ROM will jump
+    to it.
+    """
+    return make_fd("", IMAGE_ADDRS["failover"], data, executable=executable)
+
+
+def body_for(tag: str) -> bytes:
+    # 16 bytes of a tag-derived pattern; length is a multiple of 4 so the
+    # additive checksum covers all of it.
+    return bytes([sum(tag.encode()) & 0xFF]) * 16
+
+
+def bodies_for(override: Optional[dict] = None) -> dict:
+    """Image bodies keyed by tag, with any given tags substituted."""
+    bodies = {tag: body_for(tag) for tag in IMAGE_ADDRS}
+    bodies.update(override or {})
+    return bodies
+
+
+def signed_image(
+    payload: bytes,
+    signature: bytes,
+    sha256: bytes = b"\xa5" * 32,
+    keyhash: bytes = b"\x5a" * 32,
+) -> bytes:
+    """
+    An image shaped like one imgtool produces: a header, the payload, and a TLV
+    area carrying the payload hash, the signing key's hash, and the signature.
+    """
+    header = struct.pack(
+        "<IIHHI", MCUBOOT_IMAGE_MAGIC, 0, MCUBOOT_HDR_SIZE, 0, len(payload)
+    )
+    header += b"\x00" * (MCUBOOT_HDR_SIZE - len(header))
+
+    def tlv(tlv_type: int, value: bytes) -> bytes:
+        return struct.pack("<HH", tlv_type, len(value)) + value
+
+    tlvs = (
+        tlv(MCUBOOT_TLV_SHA256, sha256)
+        + tlv(MCUBOOT_TLV_KEYHASH, keyhash)
+        + tlv(TLV_RSA2048_PSS, signature)
+    )
+    info = struct.pack("<HH", TLV_INFO_MAGIC, MCUBOOT_TLV_INFO.size + len(tlvs))
+
+    return header + payload + info + tlvs
+
+
+def build_flash(
+    corrupt: set[str] = frozenset(),
+    missing: set[str] = frozenset(),
+    bodies: Optional[dict] = None,
+    failover_executable: bool = True,
+) -> bytes:
+    """
+    Build an in-memory flash with a ROM table (cmfw/safeimg/safetail) at 0x0, a
+    failover table at 0x4000, and each image body at its fixed address.
+
+    corrupt: tags whose on-chip body bytes are mangled (checksum will fail).
+    missing: tags to omit from the descriptor tables entirely.
+    bodies: image bodies to use in place of the defaults.
+    failover_executable: whether the failover descriptor is marked executable.
+    """
+    bodies = bodies_for(bodies)
+    flash = bytearray(0xC0000)
+
+    rom_fds = b"".join(
+        make_fd(tag, IMAGE_ADDRS[tag], bodies[tag])
+        for tag in ("cmfw", "safeimg", "safetail")
+        if tag not in missing
+    )
+    flash[ROM_HEAD : ROM_HEAD + len(rom_fds)] = rom_fds
+    flash[ROM_HEAD + len(rom_fds) : ROM_HEAD + len(rom_fds) + FD_SIZE] = INVALID_FD
+
+    if "failover" not in missing:
+        fo_fd = make_failover_fd(bodies["failover"], executable=failover_executable)
+        flash[FAILOVER_HEAD : FAILOVER_HEAD + FD_SIZE] = fo_fd
+    flash[FAILOVER_HEAD + FD_SIZE : FAILOVER_HEAD + 2 * FD_SIZE] = INVALID_FD
+
+    for tag, addr in IMAGE_ADDRS.items():
+        body = bytearray(bodies[tag])
+        if tag in corrupt:
+            body[0] ^= 0xFF
+        flash[addr : addr + len(body)] = body
+
+    flash[SPI_RX_ADDR : SPI_RX_ADDR + len(SPI_RX_VALUE)] = SPI_RX_VALUE
+
+    return bytes(flash)
+
+
+def build_image_writes(
+    bodies: Optional[dict] = None, failover_executable: bool = True
+) -> list[FlashWrite]:
+    """Writes as parsed from a fresh bundle: descriptor tables plus image bodies."""
+    bodies = bodies_for(bodies)
+    rom_fds = b"".join(
+        make_fd(tag, IMAGE_ADDRS[tag], bodies[tag])
+        for tag in ("cmfw", "safeimg", "safetail")
+    )
+    writes = [
+        FlashWrite(ROM_HEAD, bytearray(rom_fds + INVALID_FD)),
+        FlashWrite(
+            FAILOVER_HEAD,
+            bytearray(
+                make_failover_fd(bodies["failover"], executable=failover_executable)
+                + INVALID_FD
+            ),
+        ),
+        # cmfw merged with the training word that precedes it, as a bundle emits it.
+        FlashWrite(SPI_RX_ADDR, bytearray(SPI_RX_VALUE + bodies["cmfw"])),
+    ]
+    for tag in ("safeimg", "safetail", "failover"):
+        writes.append(FlashWrite(IMAGE_ADDRS[tag], bytearray(bodies[tag])))
+    writes.sort(key=lambda w: w.offset)
+    return writes
+
+
+def is_written(writes: list[FlashWrite], addr: int) -> bool:
+    """Whether any write would touch addr. Not the same as starting at it."""
+    return any(w.offset <= addr < w.offset + len(w.write) for w in writes)
+
+
+def fd_in_writes(writes: list[FlashWrite], tag: str) -> boot_fs.tt_boot_fs_fd:
+    """The descriptor a set of writes would put on flash for tag."""
+    for write in writes:
+        found = boot_fs.read_tag(
+            lambda addr, size: write.write[addr : addr + size], tag
+        )
+        if found is not None:
+            return found[1]
+    raise AssertionError(f"no descriptor for {tag} in writes")
+
+
+def test_skip_boot_critical_drops_identical_bodies():
+    chip = FakeChip(build_flash())
+    writes = build_image_writes()
+
+    result = skip_boot_critical(chip, writes)
+
+    # Every boot-critical image body is gone (on-chip copy identical). cmfw
+    # counts only if the merged write no longer reaches 0x14000.
+    for tag in BOOT_CRITICAL_TAGS:
+        assert not is_written(result, IMAGE_ADDRS[tag]), (
+            f"body for {tag} at 0x{IMAGE_ADDRS[tag]:x} was not skipped"
+        )
+    # The training word shares cmfw's write but is not part of the image, so it
+    # still has to be written.
+    assert is_written(result, SPI_RX_ADDR), "SPI RX training word was lost"
+    # The descriptor tables are still in the plan at this stage; they carry the
+    # resident descriptors this function just spliced in. Dropping them when
+    # they match flash is skip_unchanged_static_regions' job.
+    result_offsets = {w.offset for w in result}
+    assert ROM_HEAD in result_offsets
+    assert FAILOVER_HEAD in result_offsets
+
+
+def test_skip_boot_critical_writes_differing_image():
+    # The on-chip cmfw differs from the bundle's: its body write must be kept,
+    # otherwise the (always written) descriptor's data_crc would mismatch the
+    # image left on flash and the boot ROM would reject it.
+    chip = FakeChip(build_flash(corrupt={"cmfw"}))
+    writes = build_image_writes()
+
+    result = skip_boot_critical(chip, writes)
+
+    assert is_written(result, IMAGE_ADDRS["cmfw"]), (
+        "differing cmfw body write was skipped; descriptor and image on flash "
+        "would be inconsistent"
+    )
+    # The identical images are still skipped.
+    for tag in ("safeimg", "safetail", "failover"):
+        assert not is_written(result, IMAGE_ADDRS[tag])
+
+
+def test_skip_boot_critical_writes_everything_on_blank_chip():
+    # An unprovisioned (fully erased) chip holds no boot-critical images:
+    # every body write must be kept so the flash ends up self-consistent.
+    chip = FakeChip(b"\xff" * 0xC0000)
+    writes = build_image_writes()
+
+    result = skip_boot_critical(chip, writes)
+
+    for tag in BOOT_CRITICAL_TAGS:
+        assert is_written(result, IMAGE_ADDRS[tag]), (
+            f"body write for {tag} was skipped on an unprovisioned chip"
+        )
+
+
+def test_skip_boot_critical_ignores_a_fresh_signature():
+    # The case the content comparison exists for: the bundle holds the same
+    # recovery image the chip does, rebuilt and so signed again. Only the
+    # signature differs, and nothing should be written.
+    payload = bytes(range(64))
+    resident = signed_image(payload, signature=b"\x11" * 256)
+    rebuilt = signed_image(payload, signature=b"\x22" * 256)
+    assert resident != rebuilt
+
+    chip = FakeChip(build_flash(bodies={"safeimg": resident}))
+    writes = build_image_writes(bodies={"safeimg": rebuilt})
+
+    result = skip_boot_critical(chip, writes)
+
+    assert IMAGE_ADDRS["safeimg"] not in {w.offset for w in result}, (
+        "recovery image was rewritten even though the chip holds the same image"
+    )
+    # The descriptor left on flash has to describe the resident image, not the
+    # one the bundle would have written: their data_crc values differ because
+    # the signatures do.
+    assert fd_in_writes(result, "safeimg").data_crc == calculate_checksum(resident)
+
+
+def test_skip_boot_critical_writes_a_damaged_image():
+    # A signed image damaged on flash still carries the hash of what it was
+    # supposed to be, so only its descriptor can reveal the damage.
+    image = signed_image(bytes(range(64)), b"\x11" * 256)
+
+    chip = FakeChip(build_flash(bodies={"safeimg": image}))
+    # Flip a byte of the signature, the part of the image the content
+    # comparison deliberately ignores.
+    chip.flash[IMAGE_ADDRS["safeimg"] + len(image) - 8] ^= 0xFF
+
+    writes = build_image_writes(bodies={"safeimg": image})
+
+    result = skip_boot_critical(chip, writes)
+
+    assert IMAGE_ADDRS["safeimg"] in {w.offset for w in result}, (
+        "damaged recovery image was left on the board"
+    )
+
+
+def test_skip_boot_critical_writes_a_changed_payload():
+    # Same signing key, different payload: a real change, so it must be written.
+    resident = signed_image(bytes(range(64)), b"\x11" * 256, sha256=b"\x01" * 32)
+    updated = signed_image(bytes(range(64)), b"\x11" * 256, sha256=b"\x02" * 32)
+
+    chip = FakeChip(build_flash(bodies={"safeimg": resident}))
+    writes = build_image_writes(bodies={"safeimg": updated})
+
+    result = skip_boot_critical(chip, writes)
+
+    assert IMAGE_ADDRS["safeimg"] in {w.offset for w in result}
+    assert fd_in_writes(result, "safeimg").data_crc == calculate_checksum(updated)
+
+
+def test_skip_boot_critical_writes_a_resigned_image():
+    # Same payload, different signing key. The payload hash matches, so only
+    # the key hash can catch this; skipping it would leave an image signed by
+    # a retired key on the board.
+    payload = bytes(range(64))
+    resident = signed_image(payload, b"\x11" * 256, keyhash=b"\x01" * 32)
+    resigned = signed_image(payload, b"\x22" * 256, keyhash=b"\x02" * 32)
+
+    chip = FakeChip(build_flash(bodies={"safeimg": resident}))
+    writes = build_image_writes(bodies={"safeimg": resigned})
+
+    result = skip_boot_critical(chip, writes)
+
+    assert IMAGE_ADDRS["safeimg"] in {w.offset for w in result}
+
+
+def test_update_boot_images_writes_everything():
+    chip = FakeChip(build_flash())
+    writes = build_image_writes()
+
+    result = skip_boot_critical(chip, writes, update_boot_images=True)
+
+    for tag in BOOT_CRITICAL_TAGS:
+        assert is_written(result, IMAGE_ADDRS[tag])
+
+
+def test_skip_boot_critical_recognises_a_non_executable_failover():
+    # The failover slot is identified by its address alone. When recognising it
+    # also required the executable bit, a bundle that left that bit clear went
+    # unrecognised, and the whole failover image was rewritten on every update
+    # with nothing said about it.
+    chip = FakeChip(build_flash(failover_executable=False))
+    writes = build_image_writes(failover_executable=False)
+
+    result = skip_boot_critical(chip, writes)
+
+    assert not is_written(result, IMAGE_ADDRS["failover"]), (
+        "failover image was rewritten even though the chip holds the same one"
+    )
+
+
+def test_skip_boot_critical_writes_a_newly_executable_failover():
+    # Same image on both sides, but the board's failover descriptor is not
+    # marked executable and the bundle's is. The ROM would not boot what is on
+    # the board, and identical image bytes cannot say so, so the descriptor has
+    # to reach flash.
+    chip = FakeChip(build_flash(failover_executable=False))
+
+    chip.apply(full_plan(chip, build_image_writes()))
+
+    found = boot_fs.read_tag(lambda a, s: chip.spi_read(a, s), "failover")
+    assert found is not None
+    assert found[1].flags.f.executable, (
+        "the board was left with a failover slot the ROM will not boot"
+    )
+
+
+def test_skip_boot_critical_writes_a_changed_load_address():
+    # The image is byte for byte what the board holds, but the bundle loads it
+    # somewhere else. Nothing in the image records where it is loaded, so only
+    # the descriptor can reveal the change, and reusing the resident one would
+    # quietly drop it.
+    chip = FakeChip(build_flash())
+    writes = build_image_writes()
+    rom_write = next(w for w in writes if w.offset == ROM_HEAD)
+    rom_write.write[0:FD_SIZE] = make_fd(
+        "cmfw", IMAGE_ADDRS["cmfw"], body_for("cmfw"), copy_dest=0x20000000
+    )
+
+    chip.apply(full_plan(chip, writes))
+
+    found = boot_fs.read_tag(lambda a, s: chip.spi_read(a, s), "cmfw")
+    assert found is not None
+    assert found[1].copy_dest == 0x20000000, (
+        "the bundle's load address was dropped in favour of the resident one"
+    )
+
+
+def test_skip_boot_critical_writes_a_relocated_image():
+    # The bundle moves cmfw somewhere else. The resident descriptor cannot be
+    # reused, because it points at the old address, so the image is written in
+    # full at its new home.
+    chip = FakeChip(build_flash())
+    writes = build_image_writes()
+    moved = 0x18000
+    # At its new home cmfw no longer abuts the training word, so it gets a
+    # write of its own.
+    writes = [w for w in writes if w.offset != SPI_RX_ADDR]
+    writes.append(FlashWrite(SPI_RX_ADDR, bytearray(SPI_RX_VALUE)))
+    writes.append(FlashWrite(moved, bytearray(body_for("cmfw"))))
+    rom_write = next(w for w in writes if w.offset == ROM_HEAD)
+    rom_write.write[0:FD_SIZE] = make_fd("cmfw", moved, body_for("cmfw"))
+
+    result = skip_boot_critical(chip, writes)
+
+    assert is_written(result, moved)
+
+
+def full_plan(chip, writes, update_boot_images: bool = False) -> list[FlashWrite]:
+    """The write plan as boot_fs_write leaves it, for the boot-critical stages."""
+    writes = skip_boot_critical(chip, writes, update_boot_images)
+    return skip_unchanged_static_regions(chip, writes, update_boot_images)
+
+
+def test_static_tables_not_written_when_unchanged():
+    # The guarantee the static/mutable table split exists for: an update that
+    # changes nothing boot-critical must not write the ROM or failover tables,
+    # because writing them means erasing their sectors.
+    chip = FakeChip(build_flash())
+
+    result = full_plan(chip, build_image_writes())
+
+    result_offsets = {w.offset for w in result}
+    assert ROM_HEAD not in result_offsets, "ROM descriptor table was rewritten"
+    assert FAILOVER_HEAD not in result_offsets, "failover table was rewritten"
+
+
+def test_mcuboot_not_written_when_unchanged():
+    # cmfw is the case a fixture without the training word cannot see.
+    chip = FakeChip(build_flash())
+
+    result = full_plan(chip, build_image_writes())
+
+    assert not is_written(result, IMAGE_ADDRS["cmfw"]), (
+        "MCUBoot was rewritten even though the board holds the same image"
+    )
+
+
+def test_rom_table_written_when_a_boot_image_changed():
+    # A genuinely different cmfw: its descriptor records a data_crc over the new
+    # bytes, so it differs from the one on flash and the table has to be written
+    # alongside the image.
+    chip = FakeChip(build_flash())
+    writes = build_image_writes(bodies={"cmfw": b"\x77" * 16})
+
+    result = full_plan(chip, writes)
+
+    assert ROM_HEAD in {w.offset for w in result}, (
+        "ROM table was skipped even though cmfw's descriptor changed"
+    )
+    assert is_written(result, IMAGE_ADDRS["cmfw"])
+
+
+def test_plan_leaves_flash_self_consistent():
+    """
+    The invariant that matters, whatever gets skipped: every boot-critical
+    descriptor on flash must describe the image actually on flash. A skipped
+    table write is only correct because flash already says the right thing, so
+    check the end state rather than the plan.
+
+    Covers a board that already matches, one whose image is damaged under an
+    intact descriptor, one the bundle genuinely changes, and a blank board.
+    """
+    scenarios = {
+        "identical": (build_flash(), None),
+        "damaged": (build_flash(corrupt={"cmfw"}), None),
+        "changed": (build_flash(), {"cmfw": b"\x77" * 16}),
+        "blank": (b"\xff" * 0xC0000, None),
+    }
+
+    for name, (flash, bundle_bodies) in scenarios.items():
+        chip = FakeChip(flash)
+        chip.apply(full_plan(chip, build_image_writes(bodies=bundle_bodies)))
+
+        for tag in BOOT_CRITICAL_TAGS:
+            found = boot_fs.read_tag(lambda a, s: chip.spi_read(a, s), tag)
+            assert found is not None, f"[{name}] no descriptor for {tag} on flash"
+            fd = found[1]
+            body = chip.spi_read(fd.spi_addr, fd.flags.f.image_size)
+            assert calculate_checksum(body) == fd.data_crc, (
+                f"[{name}] {tag}: descriptor at 0x{fd.spi_addr:x} does not "
+                "describe the image on flash; the boot ROM would reject it"
+            )
+
+
+def test_static_tables_written_on_blank_chip():
+    chip = FakeChip(b"\xff" * 0xC0000)
+
+    result = full_plan(chip, build_image_writes())
+
+    result_offsets = {w.offset for w in result}
+    assert ROM_HEAD in result_offsets
+    assert FAILOVER_HEAD in result_offsets
+
+
+def test_update_boot_images_writes_static_tables():
+    chip = FakeChip(build_flash())
+
+    result = full_plan(chip, build_image_writes(), update_boot_images=True)
+
+    result_offsets = {w.offset for w in result}
+    assert ROM_HEAD in result_offsets
+    assert FAILOVER_HEAD in result_offsets
+
+
+def test_skip_boot_critical_ignores_tags_absent_from_image():
+    # A bundle that ships no boot-critical tags must be a no-op, not an error.
+    chip = FakeChip(build_flash())
+    writes = [FlashWrite(0x170000, bytearray(body_for("mainimg")))]
+
+    result = skip_boot_critical(chip, writes)
+
+    assert [w.offset for w in result] == [0x170000]

--- a/tests/test_boot_critical.py
+++ b/tests/test_boot_critical.py
@@ -22,6 +22,8 @@ from tt_flash.blackhole import (
     MCUBOOT_TLV_SHA256,
     FlashWrite,
     calculate_checksum,
+    _find_fd_in_writes,
+    boot_image_identity,
     skip_boot_critical,
     skip_unchanged_static_regions,
 )
@@ -538,3 +540,57 @@ def test_skip_boot_critical_ignores_tags_absent_from_image():
     result = skip_boot_critical(chip, writes)
 
     assert [w.offset for w in result] == [0x170000]
+
+
+def test_boot_image_identity_terminates_on_a_zero_size_tlv_section():
+    # A TLV info header claiming a total size that cannot hold a TLV leaves the
+    # section walk where it started. Taken at face value the outer loop re-reads
+    # the same header forever, hanging tt-flash mid-flash behind the spinner.
+    payload = body_for("cmfw")
+    header = struct.pack(
+        "<IIHHI", MCUBOOT_IMAGE_MAGIC, 0, MCUBOOT_HDR_SIZE, 0, len(payload)
+    )
+    header += b"\x00" * (MCUBOOT_HDR_SIZE - len(header))
+
+    for claimed in (0, 1, 2, 3, MCUBOOT_TLV_INFO.size):
+        image = header + payload + struct.pack("<HH", TLV_INFO_MAGIC, claimed)
+        # No sha256 is reachable, so the image identifies as its own bytes.
+        assert boot_image_identity(image) == image
+
+
+def test_failover_protected_when_its_table_shares_a_write():
+    # The bundle emits each contiguous run of flash as one write, so the
+    # failover table is not guaranteed to start one. Matching it by write offset
+    # alone stops protecting the failover image the moment it doesn't, silently
+    # reopening the power-loss window this whole path exists to close.
+    chip = FakeChip(build_flash())
+    writes = build_image_writes()
+
+    failover_table = next(w for w in writes if w.offset == FAILOVER_HEAD)
+    writes.remove(failover_table)
+    # Prepend the security binary descriptor slot that sits right before it.
+    pre_addr = boot_fs.TT_BOOT_FS_SECURITY_BINARY_FD_ADDR
+    pre = bytearray(chip.spi_read(pre_addr, FAILOVER_HEAD - pre_addr))
+    writes.append(FlashWrite(pre_addr, pre + failover_table.write))
+    writes.sort(key=lambda w: w.offset)
+
+    result = full_plan(chip, writes)
+
+    assert not is_written(result, IMAGE_ADDRS["failover"]), "failover body rewritten"
+    assert not is_written(result, FAILOVER_HEAD), "failover table rewritten"
+
+
+def test_failover_lookup_ignores_a_zeroed_run_at_the_wrong_address():
+    # read_tag's addresses are buffer-relative for a write, so its blank-tag
+    # rule keys on the wrong bytes for any write not starting at flash 0. A
+    # zeroed run landing at that buffer offset must not be taken for the
+    # failover descriptor.
+    writes = build_image_writes()
+    stray = FlashWrite(0x100, bytearray(FAILOVER_HEAD + FD_SIZE))
+
+    found = _find_fd_in_writes(writes + [stray], "failover")
+
+    assert found is not None
+    write, offset, fd = found
+    assert write.offset + offset == FAILOVER_HEAD
+    assert fd.spi_addr == IMAGE_ADDRS["failover"]

--- a/tests/test_boot_fs.py
+++ b/tests/test_boot_fs.py
@@ -240,3 +240,37 @@ def test_read_tag_matches_non_executable_failover_slot():
     assert addr == boot_fs.TT_BOOT_FS_FAILOVER_HEAD_ADDR
     assert fd.spi_addr == 0xB4000
     assert not fd.flags.f.executable
+
+
+def test_read_tag_scans_a_full_rom_table():
+    """
+    A pre-split flash keeps every image in the table at 0x0, which has room for
+    far more descriptors than the firmware's per-table default. Bounding the
+    scan by that default hides the tail of such a table, and the caller sees a
+    missing tag rather than a bounds problem.
+    """
+    entries = [(f"img{i:04}", 0x14000 + i * 0x1000) for i in range(64)]
+    assert len(entries) > boot_fs.MAX_FDS_PER_TABLE
+
+    flash = bytearray(b"\xff" * 0x200000)
+    rom = make_table(entries)
+    assert len(rom) <= boot_fs.TT_BOOT_FS_SECURITY_BINARY_FD_ADDR
+    flash[0 : len(rom)] = rom
+
+    reader = reader_for(bytes(flash))
+    last_tag, last_addr = entries[-1]
+    found = boot_fs.read_tag(reader, last_tag)
+
+    assert found is not None, "descriptor past the per-table default was missed"
+    assert found[1].spi_addr == last_addr
+
+
+def test_table_fd_capacity_is_bounded_by_the_next_region():
+    """Fixed tables end where the next structure in flash begins."""
+    fd_size = ctypes.sizeof(tt_boot_fs_fd)
+    assert boot_fs.table_fd_capacity(boot_fs.TT_BOOT_FS_FD_HEAD_ADDR) == (
+        boot_fs.TT_BOOT_FS_SECURITY_BINARY_FD_ADDR // fd_size
+    )
+    # A table reached through the multi-table header has no known extent, so it
+    # keeps the firmware default as a corruption backstop.
+    assert boot_fs.table_fd_capacity(0x170000) == boot_fs.MAX_FDS_PER_TABLE

--- a/tests/test_boot_fs.py
+++ b/tests/test_boot_fs.py
@@ -1,0 +1,242 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for tt_flash.boot_fs descriptor parsing.
+
+These do not require hardware. They exercise the tt-boot-fs descriptor scanner
+against the multi-table layout introduced when the mutable firmware records were
+moved out of the ROM descriptor table (ROM table at 0x0, failover table at
+0x4000, mutable table at 0x170000). tt-flash locates tags by scanning a
+descriptor region from its start, so it must resolve a tag regardless of which
+table it lives in, and must stop at a table's terminating (invalid) descriptor.
+"""
+
+import ctypes
+
+from tt_flash import boot_fs
+from tt_flash.boot_fs import tt_boot_fs_fd
+
+FD_SIZE = ctypes.sizeof(tt_boot_fs_fd)
+
+
+def make_fd(
+    tag: str, spi_addr: int = 0, image_size: int = 0, executable: bool = False
+) -> bytes:
+    """Build a single valid tt-boot-fs file descriptor for the given tag."""
+    fd = tt_boot_fs_fd()
+    fd.spi_addr = spi_addr
+    fd.flags.f.image_size = image_size
+    fd.flags.f.invalid = 0
+    fd.flags.f.executable = 1 if executable else 0
+    encoded = tag.encode("ascii")
+    assert len(encoded) <= boot_fs.IMAGE_TAG_SIZE
+    for i, ch in enumerate(encoded):
+        fd.image_tag[i] = ch
+    return bytes(fd)
+
+
+def make_table(entries: list[tuple[str, int]]) -> bytes:
+    """Build a descriptor region: valid FDs followed by an invalid terminator."""
+    blob = b"".join(make_fd(tag, spi_addr=addr) for tag, addr in entries)
+    # A descriptor with all bits set has invalid == 1 and terminates the table.
+    blob += b"\xff" * FD_SIZE
+    return blob
+
+
+def reader_for(buf: bytes):
+    return lambda addr, size: buf[addr : addr + size]
+
+
+def test_image_tag_str_stops_at_nul():
+    """Tags shorter than 8 bytes are NUL-padded and must not include padding."""
+    fd = tt_boot_fs_fd.from_buffer_copy(make_fd("cmfw"))
+    assert fd.image_tag_str() == "cmfw"
+
+    fd8 = tt_boot_fs_fd.from_buffer_copy(make_fd("boardcfg"))
+    assert fd8.image_tag_str() == "boardcfg"
+
+
+def test_read_tag_finds_short_and_full_length_tags():
+    rom = make_table([("cmfw", 0x14000), ("recovery", 0x34000), ("boardcfg", 0xD4000)])
+    reader = reader_for(rom)
+
+    for tag, expected_addr in (
+        ("cmfw", 0x14000),
+        ("recovery", 0x34000),
+        ("boardcfg", 0xD4000),
+    ):
+        found = boot_fs.read_tag(reader, tag)
+        assert found is not None, f"read_tag failed to find {tag!r}"
+        addr, fd = found
+        assert fd.spi_addr == expected_addr
+
+
+def test_read_tag_stops_at_table_terminator():
+    """A tag beyond the terminating descriptor must not be found."""
+    rom = make_table([("cmfw", 0x14000), ("boardcfg", 0xD4000)])
+    # Simulate a following table (as on flash) that must not be reached by a
+    # scan that starts in the ROM table.
+    mutable = make_table([("mainimg", 0x29E000)])
+    combined = rom + mutable
+
+    reader = reader_for(combined)
+    assert boot_fs.read_tag(reader, "boardcfg") is not None
+    assert boot_fs.read_tag(reader, "mainimg") is None
+
+
+def test_read_tag_resolves_within_each_table():
+    """
+    ROM tags resolve when scanning the ROM region; mutable tags (ccfgovra,
+    ccfgovrb, mainimg) resolve when scanning the mutable region. This mirrors
+    how blackhole.py scans each FlashWrite buffer independently.
+    """
+    rom = make_table([("cmfw", 0x14000), ("recovery", 0x34000), ("boardcfg", 0xD4000)])
+    mutable = make_table(
+        [("ccfgovra", 0x1F5000), ("ccfgovrb", 0x1F6000), ("mainimg", 0x29E000)]
+    )
+
+    rom_reader = reader_for(rom)
+    mut_reader = reader_for(mutable)
+
+    assert boot_fs.read_tag(rom_reader, "boardcfg") is not None
+    assert boot_fs.read_tag(rom_reader, "ccfgovra") is None
+
+    for tag in ("ccfgovra", "ccfgovrb", "mainimg"):
+        assert boot_fs.read_tag(mut_reader, tag) is not None
+    assert boot_fs.read_tag(mut_reader, "boardcfg") is None
+
+
+def make_header(num_tables: int, version: int = boot_fs.BOOT_FS_HEADER_VERSION,
+                magic: int = boot_fs.BOOT_FS_HEADER_MAGIC) -> bytes:
+    header = boot_fs.tt_boot_fs_header()
+    header.magic = magic
+    header.version = version
+    header.num_tables = num_tables
+    return bytes(header)
+
+
+def build_multi_table_flash() -> bytearray:
+    """Full-flash buffer with the new layout: ROM table at 0x0, failover table
+    at 0x4000, mutable table at 0x170000, TTBF header at 0x120000."""
+    flash = bytearray(b"\xff" * 0x200000)
+    rom = make_table([("cmfw", 0x14000), ("safeimg", 0x34000)])
+    failover = make_table([("failover", 0xB4000)])
+    mutable = make_table([("cmfwcfg", 0x1F7000), ("mainimg", 0x29E000)])
+    flash[0x0 : len(rom)] = rom
+    flash[0x4000 : 0x4000 + len(failover)] = failover
+    flash[0x170000 : 0x170000 + len(mutable)] = mutable
+
+    table_addrs = b"".join(a.to_bytes(4, "little") for a in (0x0, 0x4000, 0x170000))
+    header = make_header(num_tables=3) + table_addrs
+    flash[boot_fs.TT_BOOT_FS_HEADER_ADDR : boot_fs.TT_BOOT_FS_HEADER_ADDR + len(header)] = header
+    return flash
+
+
+def test_read_tag_multi_table_layout():
+    """With a valid TTBF header, tags resolve from every advertised table,
+    including the mutable table at 0x170000."""
+    reader = reader_for(bytes(build_multi_table_flash()))
+
+    for tag, expected_addr in (
+        ("cmfw", 0x14000),
+        ("safeimg", 0x34000),
+        ("failover", 0xB4000),
+        ("cmfwcfg", 0x1F7000),
+        ("mainimg", 0x29E000),
+    ):
+        found = boot_fs.read_tag(reader, tag)
+        assert found is not None, f"read_tag failed to find {tag!r}"
+        assert found[1].spi_addr == expected_addr
+
+
+def test_read_tag_legacy_layout_no_header():
+    """Without a TTBF header (legacy flash), the fixed 0x0/0x4000 tables are
+    scanned, so the failover tag still resolves."""
+    flash = bytearray(b"\xff" * 0x200000)
+    rom = make_table([("cmfw", 0x14000)])
+    failover = make_table([("failover", 0xB4000)])
+    flash[0x0 : len(rom)] = rom
+    flash[0x4000 : 0x4000 + len(failover)] = failover
+
+    reader = reader_for(bytes(flash))
+    assert boot_fs.read_tag(reader, "cmfw") is not None
+    assert boot_fs.read_tag(reader, "failover") is not None
+
+
+def test_read_tag_rejects_unknown_header_version():
+    """A TTBF header with an unsupported version must not be guessed at."""
+    flash = build_multi_table_flash()
+    bad = make_header(num_tables=3, version=boot_fs.BOOT_FS_HEADER_VERSION + 1)
+    flash[boot_fs.TT_BOOT_FS_HEADER_ADDR : boot_fs.TT_BOOT_FS_HEADER_ADDR + len(bad)] = bad
+
+    reader = reader_for(bytes(flash))
+    assert boot_fs.find_descriptor_tables(reader) == []
+    assert boot_fs.read_tag(reader, "cmfw") is None
+
+
+def test_read_tag_bounded_on_missing_terminator():
+    """A corrupt table with no terminating descriptor must not scan forever;
+    the per-table FD cap bounds the walk."""
+    # Every FD slot holds a valid-looking descriptor with a non-matching tag.
+    flash = bytes(make_fd("other")) * (boot_fs.MAX_FDS_PER_TABLE * 4)
+    assert boot_fs.read_tag(reader_for(flash), "cmfw") is None
+
+
+def test_read_tag_matches_blank_failover_by_address():
+    """
+    The failover descriptor at TT_BOOT_FS_FAILOVER_HEAD_ADDR has a blank
+    on-disk image_tag (the SMC ROM identifies it by fixed address, not tag).
+    read_tag(reader, "failover") must still resolve it when scanning the
+    failover table.
+    """
+    flash = bytearray(b"\xff" * 0x200000)
+    rom = make_table([("cmfw", 0x14000)])
+    # Failover FD with a blank tag but with the executable bit set, matching
+    # what tt_boot_fs.py mkfs now emits.
+    failover_fd = make_fd("", spi_addr=0xB4000, executable=True)
+    flash[0x0 : len(rom)] = rom
+    flash[0x4000 : 0x4000 + len(failover_fd)] = failover_fd
+
+    reader = reader_for(bytes(flash))
+    found = boot_fs.read_tag(reader, "failover")
+    assert found is not None
+    addr, fd = found
+    assert addr == boot_fs.TT_BOOT_FS_FAILOVER_HEAD_ADDR
+    assert fd.spi_addr == 0xB4000
+
+
+def test_read_tag_ignores_blank_non_failover_slot():
+    """A blank-tag descriptor NOT at the failover address is not the failover."""
+    # Put a blank executable FD at the ROM table start (not the failover
+    # address). read_tag("failover") must return None -- the blank-tag rule
+    # only applies at TT_BOOT_FS_FAILOVER_HEAD_ADDR.
+    flash = bytearray(b"\xff" * 0x200000)
+    stray = make_fd("", spi_addr=0x14000, executable=True)
+    flash[0x0 : len(stray)] = stray
+
+    reader = reader_for(bytes(flash))
+    assert boot_fs.read_tag(reader, "failover") is None
+
+
+def test_read_tag_matches_non_executable_failover_slot():
+    """
+    A blank-tag descriptor at the failover address is the failover slot even
+    when it is not marked executable. That bit says whether the ROM would boot
+    the slot, which is a question about it rather than a test of whether this
+    is it, and a caller that cannot find the slot cannot compare it against
+    the bundle's copy either.
+    """
+    flash = bytearray(b"\xff" * 0x200000)
+    rom = make_table([("cmfw", 0x14000)])
+    non_exec = make_fd("", spi_addr=0xB4000, executable=False)
+    flash[0x0 : len(rom)] = rom
+    flash[0x4000 : 0x4000 + len(non_exec)] = non_exec
+
+    reader = reader_for(bytes(flash))
+    found = boot_fs.read_tag(reader, "failover")
+    assert found is not None
+    addr, fd = found
+    assert addr == boot_fs.TT_BOOT_FS_FAILOVER_HEAD_ADDR
+    assert fd.spi_addr == 0xB4000
+    assert not fd.flags.f.executable

--- a/tests/test_validate_p300.py
+++ b/tests/test_validate_p300.py
@@ -208,6 +208,23 @@ class TestValidateP300:
         assert incomplete
         assert len(valid) == 0
 
+    def test_whole_recovery_card_is_not_broken_up_to_complete_another(self):
+        """
+        A card with both halves in recovery sitting alongside a genuinely
+        half-populated card. Taking one recovery chip completes the card that
+        is missing hardware and strands the other half of the card that is all
+        there, so the two recovery chips stay together.
+        """
+        half_populated = FakeTTChip(make_board_id(serial=0x1), 0)
+        recovery = [FakeTTChip(0x0, 0, 0x45), FakeTTChip(0x0, 1, 0x45)]
+
+        valid, incomplete = validate_p300_can_be_flashed(
+            [half_populated, *recovery]
+        )
+
+        assert incomplete, "the half-populated card should be reported"
+        assert sorted(id(c) for c in valid) == sorted(id(c) for c in recovery)
+
     def test_chip_in_recovery_alone(self):
         """A lone recovery chip is still half a card, so it is excluded."""
         valid, incomplete = validate_p300_can_be_flashed([FakeTTChip(0x0, 0, 0x45)])

--- a/tests/test_validate_p300.py
+++ b/tests/test_validate_p300.py
@@ -10,6 +10,7 @@ Usage:
 """
 
 from dataclasses import dataclass
+from typing import Optional
 
 import pytest
 
@@ -26,9 +27,17 @@ class FakeTTChip:
     """Stand-in for TTChip with only the methods used in validate_p300_can_be_flashed."""
     _board_id: int
     _asic_location: int
+    # UPI as it appears in the PCI subsystem id. A chip running recovery FW has
+    # a board_id of 0 and can only be identified through this.
+    _pci_board_type: Optional[int] = None
 
     def board_id(self) -> int:
         return self._board_id
+
+    def board_type(self) -> int:
+        if self._pci_board_type is None:
+            raise RuntimeError("Could not get PCI interface for this chip.")
+        return self._pci_board_type
 
     def get_asic_location(self) -> int:
         return self._asic_location
@@ -111,6 +120,67 @@ class TestValidateP300:
         """Three chips sharing a board_id should be rejected."""
         board_id = make_board_id()
         chips = [FakeTTChip(board_id, 0), FakeTTChip(board_id, 1), FakeTTChip(board_id, 0)]
+
+        valid, incomplete = validate_p300_can_be_flashed(chips)
+
+        assert incomplete
+        assert len(valid) == 0
+
+    def test_chip_in_recovery_pairs_with_its_sibling(self):
+        """
+        A chip running recovery FW reports no board id, so it can only be
+        placed on the card whose other half is looking for it.
+        """
+        board_id = make_board_id()
+        healthy = FakeTTChip(board_id, 1)
+        recovery = FakeTTChip(0x0, 0, _pci_board_type=0x45)
+
+        valid, incomplete = validate_p300_can_be_flashed([healthy, recovery])
+
+        assert not incomplete
+        assert valid == [healthy, recovery]
+
+    def test_both_chips_in_recovery(self):
+        """Neither chip can name its board, but the pair is still complete."""
+        chips = [FakeTTChip(0x0, 0, 0x45), FakeTTChip(0x0, 1, 0x45)]
+
+        valid, incomplete = validate_p300_can_be_flashed(chips)
+
+        assert not incomplete
+        assert len(valid) == 2
+
+    def test_chip_in_recovery_alone(self):
+        """A lone recovery chip is still half a card, so it is excluded."""
+        valid, incomplete = validate_p300_can_be_flashed([FakeTTChip(0x0, 0, 0x45)])
+
+        assert incomplete
+        assert len(valid) == 0
+
+    def test_non_p300_in_recovery(self):
+        """Boards without a second chip are not subject to the pairing check."""
+        valid, incomplete = validate_p300_can_be_flashed([FakeTTChip(0x0, 0, 0x40)])
+
+        assert not incomplete
+        assert len(valid) == 1
+
+    def test_unidentifiable_chip(self):
+        """
+        A chip that answers neither way is passed through, leaving the flash
+        path to report that it does not recognize the board.
+        """
+        valid, incomplete = validate_p300_can_be_flashed([FakeTTChip(0x0, 0)])
+
+        assert not incomplete
+        assert len(valid) == 1
+
+    def test_asic_location_cannot_be_read(self):
+        """An unreadable ASIC location excludes the board instead of raising."""
+        class UnreadableLocation(FakeTTChip):
+            def get_asic_location(self) -> int:
+                raise RuntimeError("no telemetry")
+
+        board_id = make_board_id()
+        chips = [FakeTTChip(board_id, 0), UnreadableLocation(board_id, 1)]
 
         valid, incomplete = validate_p300_can_be_flashed(chips)
 

--- a/tests/test_validate_p300.py
+++ b/tests/test_validate_p300.py
@@ -149,6 +149,65 @@ class TestValidateP300:
         assert not incomplete
         assert len(valid) == 2
 
+    def test_two_cards_each_half_in_recovery(self):
+        """
+        Two cards, each with one half in recovery, must not be cross-paired.
+        Pairing on anything but ASIC location produces two same-location pairs,
+        both of which are then rejected, leaving all four chips unflashed.
+        """
+        a = make_board_id(serial=0xA)
+        b = make_board_id(serial=0xB)
+        chips = [
+            FakeTTChip(a, 0),
+            FakeTTChip(0x0, 1, 0x45),
+            FakeTTChip(0x0, 0, 0x45),
+            FakeTTChip(b, 1),
+        ]
+
+        valid, incomplete = validate_p300_can_be_flashed(chips)
+
+        assert not incomplete
+        assert len(valid) == 4
+
+    def test_unreadable_location_does_not_strand_pairable_chips(self):
+        """
+        A recovery chip whose ASIC location cannot be read is set aside, not
+        treated as the end of the pairing pass. Ending the pass there would
+        leave the chips behind it unpaired and so unflashed, on an ordering
+        that says nothing about the hardware.
+        """
+        class UnreadableLocation(FakeTTChip):
+            def get_asic_location(self) -> int:
+                raise RuntimeError("no telemetry")
+
+        pairable = [FakeTTChip(0x0, 0, 0x45), FakeTTChip(0x0, 1, 0x45)]
+        unreadable = UnreadableLocation(0x0, 0, 0x45)
+
+        for chips in ([*pairable, unreadable], [unreadable, *pairable]):
+            valid, incomplete = validate_p300_can_be_flashed(chips)
+
+            assert incomplete, "the unpairable chip should still be reported"
+            assert sorted(id(c) for c in valid) == sorted(id(c) for c in pairable)
+
+    def test_ambiguous_recovery_chip_is_not_adopted(self):
+        """
+        With two cards each missing a half, nothing says which one a lone
+        recovery chip belongs to. Guessing reports a pair drawn from two
+        different cards as complete, so no adoption happens at all.
+        """
+        a = make_board_id(serial=0xA)
+        b = make_board_id(serial=0xB)
+        chips = [
+            FakeTTChip(a, 0),
+            FakeTTChip(b, 0),
+            FakeTTChip(0x0, 1, 0x45),
+        ]
+
+        valid, incomplete = validate_p300_can_be_flashed(chips)
+
+        assert incomplete
+        assert len(valid) == 0
+
     def test_chip_in_recovery_alone(self):
         """A lone recovery chip is still half a card, so it is excluded."""
         valid, incomplete = validate_p300_can_be_flashed([FakeTTChip(0x0, 0, 0x45)])

--- a/tt_flash/blackhole.py
+++ b/tt_flash/blackhole.py
@@ -272,7 +272,10 @@ def _find_fd_in_writes(
             fd = boot_fs.read_fd(
                 lambda addr, size: write.write[addr : addr + size], fd_offset
             )
-            if fd is not None and fd.flags.f.invalid == 0 and fd.image_tag_str() == "":
+            if fd is not None and fd.flags.f.invalid == 0 and fd.image_tag_str() in (
+                "",
+                "failover",
+            ):
                 return write, fd_offset, fd
             continue
 

--- a/tt_flash/blackhole.py
+++ b/tt_flash/blackhole.py
@@ -260,21 +260,27 @@ def _find_fd_in_writes(
     silently stop protecting the failover image the moment it didn't.
     """
     for write in writes:
-        found = boot_fs.read_tag(
-            lambda addr, size: write.write[addr : addr + size], tag
-        )
-        if found is not None:
-            return write, found[0], found[1]
-
         if tag == "failover":
+            # Asked by address alone, never by tag. read_tag's addresses are
+            # buffer-relative here, so its own blank-tag rule -- which keys on
+            # the flash address TT_BOOT_FS_FAILOVER_HEAD_ADDR -- lands on the
+            # wrong bytes for any write that doesn't start at flash 0, and would
+            # claim a zeroed run there as the failover descriptor.
             fd_offset = boot_fs.TT_BOOT_FS_FAILOVER_HEAD_ADDR - write.offset
             if fd_offset < 0:
                 continue
             fd = boot_fs.read_fd(
                 lambda addr, size: write.write[addr : addr + size], fd_offset
             )
-            if fd is not None and fd.flags.f.invalid == 0:
+            if fd is not None and fd.flags.f.invalid == 0 and fd.image_tag_str() == "":
                 return write, fd_offset, fd
+            continue
+
+        found = boot_fs.read_tag(
+            lambda addr, size: write.write[addr : addr + size], tag
+        )
+        if found is not None:
+            return write, found[0], found[1]
 
     return None
 

--- a/tt_flash/blackhole.py
+++ b/tt_flash/blackhole.py
@@ -253,8 +253,11 @@ def _find_fd_in_writes(
 
     The failover descriptor has a blank on-disk image_tag (the SMC ROM
     identifies it by its fixed address, not by tag), so the by-tag scan cannot
-    find it. Match it by write offset instead: a write whose offset equals
-    TT_BOOT_FS_FAILOVER_HEAD_ADDR starts with the failover descriptor.
+    find it. Match it by flash address instead, looking for the write that
+    *contains* TT_BOOT_FS_FAILOVER_HEAD_ADDR rather than one that starts there:
+    the bundle emits each contiguous run of flash as a single write, so the
+    failover table need not begin one, and matching on offset alone would
+    silently stop protecting the failover image the moment it didn't.
     """
     for write in writes:
         found = boot_fs.read_tag(
@@ -263,12 +266,15 @@ def _find_fd_in_writes(
         if found is not None:
             return write, found[0], found[1]
 
-        if tag == "failover" and write.offset == boot_fs.TT_BOOT_FS_FAILOVER_HEAD_ADDR:
+        if tag == "failover":
+            fd_offset = boot_fs.TT_BOOT_FS_FAILOVER_HEAD_ADDR - write.offset
+            if fd_offset < 0:
+                continue
             fd = boot_fs.read_fd(
-                lambda addr, size: write.write[addr : addr + size], 0
+                lambda addr, size: write.write[addr : addr + size], fd_offset
             )
             if fd is not None and fd.flags.f.invalid == 0:
-                return write, 0, fd
+                return write, fd_offset, fd
 
     return None
 
@@ -419,6 +425,20 @@ STATIC_REGION_ADDRS = (
 )
 
 
+def _covers_static_region(write: FlashWrite) -> bool:
+    """
+    Whether a write lands on one of the fixed regions.
+
+    Containment, not equality: a static region is not guaranteed to start a
+    write of its own, and a write that carries one along with its neighbours
+    still erases that region's sector. Such a write is skipped only when all of
+    its bytes are already on flash, so covering more than the region itself
+    costs nothing but the comparison.
+    """
+    end = write.offset + len(write.write)
+    return any(write.offset <= addr < end for addr in STATIC_REGION_ADDRS)
+
+
 def skip_unchanged_static_regions(
     chip: BhChip, writes: list[FlashWrite], update_boot_images: bool = False
 ) -> list[FlashWrite]:
@@ -436,7 +456,7 @@ def skip_unchanged_static_regions(
 
     kept = []
     for write in writes:
-        if write.offset in STATIC_REGION_ADDRS:
+        if _covers_static_region(write):
             resident = chip.spi_read(write.offset, len(write.write))
             if resident == bytes(write.write):
                 continue

--- a/tt_flash/blackhole.py
+++ b/tt_flash/blackhole.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
+import struct
 from base64 import b16decode
 from dataclasses import dataclass
 from typing import Optional
@@ -144,6 +145,299 @@ def skip_ccfgovr(chip: BhChip, writes: list[FlashWrite]) -> list[FlashWrite]:
     return writes
 
 
+# Boot-critical images provide the path by which the board boots at all: the
+# SMC MCUBoot bootloader (cmfw), its recovery image (safeimg) and trailer
+# (safetail), and the bootrom failover MCUBoot (failover). They live in the ROM
+# (0x0) and failover (0x4000) descriptor tables. A field update should not
+# rewrite them, so a power loss during an update cannot corrupt the fallback
+# boot path.
+BOOT_CRITICAL_TAGS = ("cmfw", "safeimg", "safetail", "failover")
+
+# MCUBoot image header and TLV area, as written by imgtool.
+MCUBOOT_IMAGE_MAGIC = 0x96F3B83D
+MCUBOOT_HEADER = struct.Struct("<IIHHI")  # magic, load_addr, hdr_size, prot_tlv_size, img_size
+MCUBOOT_TLV_INFO = struct.Struct("<HH")  # magic, total size
+MCUBOOT_TLV = struct.Struct("<HH")  # type, size
+MCUBOOT_TLV_INFO_MAGICS = (0x6907, 0x6908)
+MCUBOOT_TLV_KEYHASH = 0x01
+MCUBOOT_TLV_SHA256 = 0x10
+
+
+def boot_image_identity(image: bytes) -> bytes:
+    """
+    Return a value identifying what a boot image contains, ignoring its signature.
+
+    Signing is not reproducible: two builds of the same source produce images
+    that are identical except for the trailing signature, so raw bytes cannot
+    tell a rebuild apart from a real change. imgtool records a SHA-256 over the
+    header and payload in the image's TLV area, and a hash of the signing key
+    beside it; together they answer both "does this hold the same image" and
+    "was it signed by the same key", the second of which matters because a key
+    rotation leaves the payload hash untouched.
+
+    An image with no MCUBoot header (MCUBoot itself) carries no signature and is
+    reproducible, so it identifies as its own bytes. So does a signed image
+    whose TLV area cannot be parsed, which costs an unnecessary rewrite but
+    never skips one that was needed.
+    """
+    if len(image) < MCUBOOT_HEADER.size:
+        return image
+
+    magic, _, hdr_size, _, img_size = MCUBOOT_HEADER.unpack_from(image)
+    if magic != MCUBOOT_IMAGE_MAGIC:
+        return image
+
+    sha256 = None
+    keyhash = None
+
+    # Protected and unprotected TLVs sit in separate sections, each introduced
+    # by its own info header, so walk sections until one doesn't start with a
+    # recognised magic.
+    offset = hdr_size + img_size
+    while offset + MCUBOOT_TLV_INFO.size <= len(image):
+        info_magic, info_size = MCUBOOT_TLV_INFO.unpack_from(image, offset)
+        if info_magic not in MCUBOOT_TLV_INFO_MAGICS:
+            break
+
+        section_end = min(offset + info_size, len(image))
+        pos = offset + MCUBOOT_TLV_INFO.size
+        while pos + MCUBOOT_TLV.size <= section_end:
+            tlv_type, tlv_size = MCUBOOT_TLV.unpack_from(image, pos)
+            value = image[pos + MCUBOOT_TLV.size : pos + MCUBOOT_TLV.size + tlv_size]
+            if tlv_type == MCUBOOT_TLV_SHA256:
+                sha256 = value
+            elif tlv_type == MCUBOOT_TLV_KEYHASH:
+                keyhash = value
+            pos += MCUBOOT_TLV.size + tlv_size
+
+        offset = section_end
+
+    if sha256 is None:
+        return image
+
+    return sha256 + (keyhash or b"")
+
+
+def descriptor_identity(fd: boot_fs.tt_boot_fs_fd) -> bytes:
+    """
+    A descriptor's fields other than the checksums, for comparing two of them.
+
+    data_crc covers the image bytes, which differ between two builds of the
+    same source because signing is not reproducible, and fd_crc is derived from
+    the rest of the descriptor. Everything else -- where the image lives, where
+    it is loaded, whether the ROM executes it, its size and security flags --
+    has to match before the resident descriptor can stand in for the bundle's.
+    """
+    copy = boot_fs.tt_boot_fs_fd.from_buffer_copy(bytes(fd))
+    copy.data_crc = 0
+    copy.fd_crc = 0
+    return bytes(copy)
+
+
+def _find_fd_in_writes(
+    writes: list[FlashWrite], tag: str
+) -> Optional[tuple[FlashWrite, int, boot_fs.tt_boot_fs_fd]]:
+    """
+    Locate tag's FD among the image writes.
+
+    Returns the write holding the descriptor, the descriptor's offset within
+    that write, and the descriptor itself, or None if the image doesn't carry
+    this tag.
+
+    The failover descriptor has a blank on-disk image_tag (the SMC ROM
+    identifies it by its fixed address, not by tag), so the by-tag scan cannot
+    find it. Match it by write offset instead: a write whose offset equals
+    TT_BOOT_FS_FAILOVER_HEAD_ADDR starts with the failover descriptor.
+    """
+    for write in writes:
+        found = boot_fs.read_tag(
+            lambda addr, size: write.write[addr : addr + size], tag
+        )
+        if found is not None:
+            return write, found[0], found[1]
+
+        if tag == "failover" and write.offset == boot_fs.TT_BOOT_FS_FAILOVER_HEAD_ADDR:
+            fd = boot_fs.read_fd(
+                lambda addr, size: write.write[addr : addr + size], 0
+            )
+            if fd is not None and fd.flags.f.invalid == 0:
+                return write, 0, fd
+
+    return None
+
+
+def _find_body_write(
+    writes: list[FlashWrite], spi_addr: int, size: int
+) -> Optional[tuple[FlashWrite, int]]:
+    """
+    Locate the write carrying an image's bytes, and the image's offset within it.
+
+    An image body does not always get a write of its own. The bundle emits each
+    contiguous run of flash as a single write, so the SPI RX training word at
+    0x13FFC arrives merged with the MCUBoot image that begins right after it at
+    0x14000. Matching a write by its offset alone therefore misses MCUBoot on
+    every real bundle, which is why this looks for the write that *contains* the
+    image instead.
+    """
+    for write in writes:
+        start = spi_addr - write.offset
+        if start >= 0 and start + size <= len(write.write):
+            return write, start
+    return None
+
+
+def _without_range(write: FlashWrite, start: int, size: int) -> list[FlashWrite]:
+    """
+    The writes still needed once [start, start+size) is skipped.
+
+    Usually the skipped image is the whole write and nothing remains, but when
+    it shares a write with adjacent data -- the training word ahead of MCUBoot
+    -- that data still has to be written.
+    """
+    remaining = []
+    if start > 0:
+        remaining.append(FlashWrite(write.offset, write.write[:start]))
+    end = start + size
+    if end < len(write.write):
+        remaining.append(FlashWrite(write.offset + end, write.write[end:]))
+    return remaining
+
+
+def skip_boot_critical(
+    chip: BhChip, writes: list[FlashWrite], update_boot_images: bool = False
+) -> list[FlashWrite]:
+    """
+    Leave each boot-critical image alone when the chip already holds the same
+    image, so a routine field update never erases or rewrites the boot-critical
+    flash sectors (avoiding a power-loss window that could corrupt the fallback
+    boot path).
+
+    "The same image" is a comparison of content, not of raw bytes, because
+    signing is not reproducible; see boot_image_identity.
+
+    Skipping means keeping the resident descriptor as well as the resident
+    image. The two have to move together: the bundle's descriptor records a
+    data_crc over the bundle's bytes, so writing it while leaving the resident
+    image in place would describe an image that is not on flash -- a
+    combination the boot ROM rejects, on both the primary and failover paths.
+    For the same reason the resident descriptor is only reused when it says
+    what the bundle's descriptor says apart from that checksum. A bundle that
+    relocates a boot-critical image, loads it somewhere else, or changes
+    whether the ROM executes it is changing something the image bytes do not
+    carry, so it writes the descriptor and the image in full.
+
+    When the on-chip copy differs (an unprovisioned board, a damaged image, or
+    a genuine change to a boot image), both writes are kept, restoring a
+    consistent state. Set update_boot_images to write the bundle's own images
+    unconditionally.
+    """
+    if update_boot_images:
+        return writes
+
+    for tag in BOOT_CRITICAL_TAGS:
+        found = _find_fd_in_writes(writes, tag)
+        if found is None:
+            # This board's image doesn't ship this tag; nothing to skip.
+            continue
+        table_write, fd_offset, image_fd = found
+
+        image_size = image_fd.flags.f.image_size
+        body = _find_body_write(writes, image_fd.spi_addr, image_size)
+        if body is None:
+            continue
+        body_write, body_offset = body
+
+        resident = boot_fs.read_tag(
+            lambda addr, size: chip.spi_read(addr, size), tag
+        )
+        if resident is None:
+            # Nothing on the chip to keep, so write the bundle's copy.
+            continue
+        resident_fd = resident[1]
+
+        if descriptor_identity(resident_fd) != descriptor_identity(image_fd):
+            print(
+                f"Boot-critical image '{tag}' is described differently by the "
+                "firmware bundle than by the chip; it will be rewritten. Do "
+                "not power off the board until the update completes."
+            )
+            continue
+
+        resident_image = chip.spi_read(
+            resident_fd.spi_addr, resident_fd.flags.f.image_size
+        )
+        if calculate_checksum(resident_image) != resident_fd.data_crc:
+            # The image on flash isn't the one its descriptor describes. The
+            # content comparison below cannot catch this on its own, since a
+            # damaged image still carries the hash of what it was meant to be,
+            # so the descriptor is what reveals it.
+            print(
+                f"Boot-critical image '{tag}' on the chip does not match its "
+                "descriptor; it will be rewritten. Do not power off the board "
+                "until the update completes."
+            )
+            continue
+
+        bundle_image = bytes(body_write.write[body_offset : body_offset + image_size])
+        if boot_image_identity(resident_image) != boot_image_identity(bundle_image):
+            print(
+                f"Boot-critical image '{tag}' on the chip differs from the "
+                "firmware bundle; it will be rewritten. Do not power off the "
+                "board until the update completes."
+            )
+            continue
+
+        # Keep the descriptor that describes the image actually on flash.
+        resident_fd_bytes = bytes(resident_fd)
+        table_write.write[fd_offset : fd_offset + len(resident_fd_bytes)] = (
+            resident_fd_bytes
+        )
+        writes = [w for w in writes if w is not body_write] + _without_range(
+            body_write, body_offset, image_size
+        )
+        writes.sort(key=lambda w: w.offset)
+
+    return writes
+
+
+# Fixed-address regions below the first image that a field update has no reason
+# to change: the two descriptor tables the SMC ROM reads, and the SPI RX training
+# word. Not writing them is the whole point -- a write into a sector erases that
+# sector first, which is the power-loss window the static/mutable table split
+# exists to close.
+STATIC_REGION_ADDRS = (
+    boot_fs.TT_BOOT_FS_FD_HEAD_ADDR,
+    boot_fs.TT_BOOT_FS_FAILOVER_HEAD_ADDR,
+    boot_fs.TT_BOOT_FS_SPI_RX_ADDR,
+)
+
+
+def skip_unchanged_static_regions(
+    chip: BhChip, writes: list[FlashWrite], update_boot_images: bool = False
+) -> list[FlashWrite]:
+    """
+    Drop writes to those regions when the board already holds exactly those bytes.
+
+    This has to run after every handler that edits a descriptor in place
+    (skip_boot_critical, writeback_boardcfg), so that what gets compared is what
+    would actually reach flash. When a boot-critical image did change, its
+    descriptor still carries the bundle's data_crc, the comparison fails, and the
+    table is written as before.
+    """
+    if update_boot_images:
+        return writes
+
+    kept = []
+    for write in writes:
+        if write.offset in STATIC_REGION_ADDRS:
+            resident = chip.spi_read(write.offset, len(write.write))
+            if resident == bytes(write.write):
+                continue
+        kept.append(write)
+
+    return kept
+
+
 TAG_HANDLERS = {"write-boardcfg": writeback_boardcfg}
 
 
@@ -179,7 +473,11 @@ def parse_writes_from_image(image: bytes) -> list[FlashWrite]:
 
 
 def boot_fs_write(
-    chip: BhChip, boardname_to_display: str, mask: list[dict], writes: list[FlashWrite]
+    chip: BhChip,
+    boardname_to_display: str,
+    mask: list[dict],
+    writes: list[FlashWrite],
+    update_boot_images: bool = False,
 ) -> list[FlashWrite]:
     """
     Apply board-specific modifications to writes using tags from the mask. Process the mask tags to determine which tag handlers
@@ -190,6 +488,8 @@ def boot_fs_write(
         boardname_to_display: boardname of the chip, used for generating error messages
         mask: list of dicts containing tags
         writes: list of FlashWrites to be modified by tag handlers
+        update_boot_images: write the bundle's boot-critical images even when
+            the chip already holds the same ones
 
     Returns:
         list of FlashWrites modified by tag handlers
@@ -226,5 +526,14 @@ def boot_fs_write(
     # Triggered by the FD entries being present in the image, not by a
     # mask.json tag, so older bundles without ccfgovr remain a no-op.
     writes = skip_ccfgovr(chip, writes)
+
+    # Leave the boot-critical images alone unless they actually changed (or the
+    # user asked for them): rewriting them only risks corrupting the fallback
+    # boot path.
+    writes = skip_boot_critical(chip, writes, update_boot_images)
+
+    # Last, once every handler has settled what the descriptors will say: if a
+    # fixed ROM-region write would go back unchanged, don't write it at all.
+    writes = skip_unchanged_static_regions(chip, writes, update_boot_images)
 
     return writes

--- a/tt_flash/blackhole.py
+++ b/tt_flash/blackhole.py
@@ -199,6 +199,13 @@ def boot_image_identity(image: bytes) -> bytes:
         if info_magic not in MCUBOOT_TLV_INFO_MAGICS:
             break
 
+        if info_size <= MCUBOOT_TLV_INFO.size:
+            # A section that doesn't extend past its own info header carries no
+            # TLVs and, taken at face value, would leave offset where it is.
+            # Truncated or zeroed TLV areas reach here, so stop rather than
+            # re-read the same header forever.
+            break
+
         section_end = min(offset + info_size, len(image))
         pos = offset + MCUBOOT_TLV_INFO.size
         while pos + MCUBOOT_TLV.size <= section_end:

--- a/tt_flash/boot_fs.py
+++ b/tt_flash/boot_fs.py
@@ -22,9 +22,17 @@ BOOT_FS_HEADER_MAGIC = 0x54544246  # 'TTBF' in ASCII, little-endian
 BOOT_FS_HEADER_VERSION = 1
 
 # Upper bounds when walking flash that may be corrupt. The per-table FD cap
-# matches the firmware's CONFIG_TT_BOOT_FS_IMAGE_COUNT_MAX default.
+# matches the firmware's CONFIG_TT_BOOT_FS_IMAGE_COUNT_MAX default, and applies
+# to tables whose extent isn't known; the fixed tables are bounded by what
+# follows them in flash instead. A pre-split flash keeps every image in the
+# table at 0x0, which can hold far more than the firmware default, so capping
+# that scan at the default would hide the tail of the table.
 MAX_TABLES = 16
 MAX_FDS_PER_TABLE = 32
+TABLE_REGION_END = {
+    TT_BOOT_FS_FD_HEAD_ADDR: TT_BOOT_FS_SECURITY_BINARY_FD_ADDR,
+    TT_BOOT_FS_FAILOVER_HEAD_ADDR: TT_BOOT_FS_SPI_RX_ADDR,
+}
 
 
 class ExtendedStructure(ctypes.Structure):
@@ -200,6 +208,19 @@ def find_descriptor_tables(reader: Callable[[int, int], bytes]) -> list:
     return table_addrs
 
 
+def table_fd_capacity(table_addr: int) -> int:
+    """
+    How many descriptors a table can hold before it runs into whatever follows
+    it in flash. Tables at an address with no known successor fall back to the
+    firmware's per-table default.
+    """
+    region_end = TABLE_REGION_END.get(table_addr)
+    if region_end is None or region_end <= table_addr:
+        return MAX_FDS_PER_TABLE
+
+    return (region_end - table_addr) // ctypes.sizeof(tt_boot_fs_fd)
+
+
 def read_tag(
     reader: Callable[[int, int], bytes], tag: str
 ) -> Optional[Tuple[int, tt_boot_fs_fd]]:
@@ -220,7 +241,7 @@ def read_tag(
     """
     for table_addr in find_descriptor_tables(reader):
         curr_addr = table_addr
-        for _ in range(MAX_FDS_PER_TABLE):
+        for _ in range(table_fd_capacity(table_addr)):
             fd = read_fd(reader, curr_addr)
 
             if fd is None or fd.flags.f.invalid != 0:

--- a/tt_flash/boot_fs.py
+++ b/tt_flash/boot_fs.py
@@ -10,6 +10,22 @@ TT_BOOT_FS_SECURITY_BINARY_FD_ADDR = 0x3FE0
 TT_BOOT_FS_FAILOVER_HEAD_ADDR = 0x4000
 IMAGE_TAG_SIZE = 8
 
+# SPI RX training word, the last four bytes of the region the SMC ROM reads
+# before the first image at 0x14000. The bundle carries it as a fixed value.
+TT_BOOT_FS_SPI_RX_ADDR = 0x13FFC
+
+# Multi-table boot filesystems advertise their descriptor tables through a
+# header at this fixed flash address. The header is not read by the SMC ROM
+# (which uses the fixed 0x0/0x4000 tables); it exists for firmware and tooling.
+TT_BOOT_FS_HEADER_ADDR = 0x120000
+BOOT_FS_HEADER_MAGIC = 0x54544246  # 'TTBF' in ASCII, little-endian
+BOOT_FS_HEADER_VERSION = 1
+
+# Upper bounds when walking flash that may be corrupt. The per-table FD cap
+# matches the firmware's CONFIG_TT_BOOT_FS_IMAGE_COUNT_MAX default.
+MAX_TABLES = 16
+MAX_FDS_PER_TABLE = 32
+
 
 class ExtendedStructure(ctypes.Structure):
     def __eq__(self, other):
@@ -121,10 +137,23 @@ class tt_boot_fs_fd(ExtendedStructure):
     def image_tag_str(self):
         output = ""
         for c in self.image_tag:
-            if c == "\0":
+            # image_tag is a c_uint8 array, so each element is an int; the tag
+            # is NUL-padded to IMAGE_TAG_SIZE. Stop at the first NUL so tags
+            # shorter than 8 bytes (e.g. "cmfw") compare correctly.
+            if c == 0:
                 break
             output += chr(c)
         return output
+
+
+# Header for a multi-table boot fs. Describes the number of descriptor tables;
+# the 32-bit flash address of each table immediately follows the header.
+class tt_boot_fs_header(ExtendedStructure):
+    _fields_ = [
+        ("magic", ctypes.c_uint32),
+        ("version", ctypes.c_uint32),
+        ("num_tables", ctypes.c_uint32),
+    ]
 
 
 def read_fd(reader, addr: int) -> Optional[tt_boot_fs_fd]:
@@ -135,17 +164,78 @@ def read_fd(reader, addr: int) -> Optional[tt_boot_fs_fd]:
     return tt_boot_fs_fd.from_buffer_copy(fd)
 
 
+def read_header(reader, addr: int) -> Optional[tt_boot_fs_header]:
+    header_size = ctypes.sizeof(tt_boot_fs_header)
+    raw = reader(addr, header_size)
+    if len(raw) < header_size:
+        return None
+    return tt_boot_fs_header.from_buffer_copy(raw)
+
+
+def find_descriptor_tables(reader: Callable[[int, int], bytes]) -> list:
+    """
+    Return the flash addresses of every descriptor table advertised by the
+    boot fs header at TT_BOOT_FS_HEADER_ADDR.
+
+    Falls back to the legacy fixed layout (ROM table at 0x0, failover table at
+    0x4000) when there is no valid header: either the flash predates the
+    multi-table layout, or the reader is backed by a buffer (e.g. a single
+    FlashWrite chunk) that does not extend to the header address.
+    """
+    header = read_header(reader, TT_BOOT_FS_HEADER_ADDR)
+    if header is None or header.magic != BOOT_FS_HEADER_MAGIC:
+        return [TT_BOOT_FS_FD_HEAD_ADDR, TT_BOOT_FS_FAILOVER_HEAD_ADDR]
+    if header.version != BOOT_FS_HEADER_VERSION or header.num_tables > MAX_TABLES:
+        # A TTBF header we don't understand: don't guess at the layout.
+        return []
+
+    table_addrs = []
+    addr = TT_BOOT_FS_HEADER_ADDR + ctypes.sizeof(tt_boot_fs_header)
+    for _ in range(header.num_tables):
+        raw = reader(addr, 4)
+        if len(raw) < 4:
+            break
+        table_addrs.append(int.from_bytes(raw, "little"))
+        addr += 4
+    return table_addrs
+
+
 def read_tag(
     reader: Callable[[int, int], bytes], tag: str
 ) -> Optional[Tuple[int, tt_boot_fs_fd]]:
-    curr_addr = 0
-    while True:
-        fd = read_fd(reader, curr_addr)
+    """
+    Find the file descriptor for `tag`, scanning every descriptor table in the
+    boot filesystem. Returns (fd_flash_addr, fd), or None if not found.
 
-        if fd is None or fd.flags.f.invalid != 0:
-            return None
+    The failover descriptor at TT_BOOT_FS_FAILOVER_HEAD_ADDR carries a blank
+    image_tag on disk, because the SMC ROM identifies the failover slot by its
+    fixed address rather than by tag. A caller asking for "failover" therefore
+    also accepts a valid descriptor at that address whose on-disk tag is empty.
 
-        if fd.image_tag_str() == tag:
-            return curr_addr, fd
+    Identifying it is deliberately a question of address alone. Whether the
+    descriptor is marked executable says whether the ROM would boot it, not
+    whether it is the failover slot, and a caller that cannot recognise a
+    failover slot cannot reason about it either -- which for skip_boot_critical
+    would mean silently rewriting the failover image on every update.
+    """
+    for table_addr in find_descriptor_tables(reader):
+        curr_addr = table_addr
+        for _ in range(MAX_FDS_PER_TABLE):
+            fd = read_fd(reader, curr_addr)
 
-        curr_addr += ctypes.sizeof(tt_boot_fs_fd)
+            if fd is None or fd.flags.f.invalid != 0:
+                break
+
+            if fd.image_tag_str() == tag:
+                return curr_addr, fd
+
+            if (
+                tag == "failover"
+                and curr_addr == TT_BOOT_FS_FAILOVER_HEAD_ADDR
+                and fd.image_tag_str() == ""
+            ):
+                return curr_addr, fd
+
+            curr_addr += ctypes.sizeof(tt_boot_fs_fd)
+
+    return None

--- a/tt_flash/chip.py
+++ b/tt_flash/chip.py
@@ -373,6 +373,40 @@ def _take_complement(pool: list[BhChip], chip: BhChip) -> Optional[BhChip]:
     return None
 
 
+def _adopt_recovery_chips(groups: list[list[BhChip]], pool: list[BhChip]) -> None:
+    """
+    Give each group that is short a chip the recovery chip belonging to it,
+    where the pool leaves only one possible answer.
+
+    A recovery chip publishes no board id, so the only thing placing it is the
+    ASIC location it fills. That is enough when one group is missing a location
+    and one chip in the pool sits there. It is not enough when two groups are
+    missing the same location: any assignment completes both, and a wrong one
+    reports a pair drawn from two different cards as a whole board, flashing
+    half of each while the card that is genuinely incomplete goes unreported.
+    Leave those groups alone and let them be reported as incomplete.
+    """
+    short_by_need: dict[int, list[list[BhChip]]] = defaultdict(list)
+    for chips in groups:
+        if len(chips) != 1:
+            continue
+        location = _asic_location(chips[0])
+        if location is not None:
+            short_by_need[1 - location].append(chips)
+
+    pool_by_location: dict[int, list[BhChip]] = defaultdict(list)
+    for chip in pool:
+        location = _asic_location(chip)
+        if location is not None:
+            pool_by_location[location].append(chip)
+
+    for need, candidates in short_by_need.items():
+        available = pool_by_location[need]
+        if len(candidates) == 1 and len(available) == 1:
+            candidates[0].append(available[0])
+            pool.remove(available[0])
+
+
 def validate_p300_can_be_flashed(
     devices: list[Union[WhChip, BhChip]],
 ) -> tuple[list[Union[WhChip, BhChip]], bool]:
@@ -416,25 +450,27 @@ def validate_p300_can_be_flashed(
             unidentified.append(dev)
 
     boards: list[tuple[Optional[int], list[BhChip]]] = []
+
+    _adopt_recovery_chips(list(p300_groups.values()), unidentified)
     for board_id, chips in p300_groups.items():
-        if len(chips) == 1 and unidentified:
-            sibling = _take_complement(unidentified, chips[0])
-            if sibling is not None:
-                chips.append(sibling)
         boards.append((board_id, chips))
 
     # Cards with neither chip able to name its board. The board id that would
     # group them is exactly what recovery firmware doesn't publish, so ASIC
-    # location is all there is to pair on.
+    # location is all there is to pair on. A chip nothing complements is set
+    # aside rather than ending the pass, so it cannot strand the chips behind
+    # it that would have paired.
+    unpairable: list[BhChip] = []
     while len(unidentified) >= 2:
         chip = unidentified.pop()
         sibling = _take_complement(unidentified, chip)
         if sibling is None:
-            unidentified.append(chip)
-            break
+            unpairable.append(chip)
+            continue
         boards.append((None, [chip, sibling]))
-    if unidentified:
-        boards.append((None, list(unidentified)))
+    unpairable.extend(unidentified)
+    if unpairable:
+        boards.append((None, unpairable))
 
     has_incomplete = False
 

--- a/tt_flash/chip.py
+++ b/tt_flash/chip.py
@@ -379,12 +379,19 @@ def _adopt_recovery_chips(groups: list[list[BhChip]], pool: list[BhChip]) -> Non
     where the pool leaves only one possible answer.
 
     A recovery chip publishes no board id, so the only thing placing it is the
-    ASIC location it fills. That is enough when one group is missing a location
-    and one chip in the pool sits there. It is not enough when two groups are
-    missing the same location: any assignment completes both, and a wrong one
-    reports a pair drawn from two different cards as a whole board, flashing
-    half of each while the card that is genuinely incomplete goes unreported.
-    Leave those groups alone and let them be reported as incomplete.
+    ASIC location it fills. Two things make that ambiguous, and either one means
+    leaving the group short and letting it be reported as incomplete.
+
+    Two groups missing the same location: any assignment completes both, and a
+    wrong one reports a pair drawn from two different cards as a whole board,
+    flashing half of each while the card that is genuinely incomplete goes
+    unreported.
+
+    A candidate whose own complement is sitting unclaimed in the pool: those two
+    are a card in their own right, and taking one of them would flash a
+    half-populated card while breaking up a whole one. A complement that another
+    short group is waiting for is not unclaimed, which is what still lets two
+    cards that are each half in recovery resolve.
     """
     short_by_need: dict[int, list[list[BhChip]]] = defaultdict(list)
     for chips in groups:
@@ -400,9 +407,11 @@ def _adopt_recovery_chips(groups: list[list[BhChip]], pool: list[BhChip]) -> Non
         if location is not None:
             pool_by_location[location].append(chip)
 
-    for need, candidates in short_by_need.items():
+    for need in (0, 1):
+        candidates = short_by_need[need]
         available = pool_by_location[need]
-        if len(candidates) == 1 and len(available) == 1:
+        unclaimed = len(pool_by_location[1 - need]) - len(short_by_need[1 - need])
+        if len(candidates) == 1 and len(available) == 1 and unclaimed <= 0:
             candidates[0].append(available[0])
             pool.remove(available[0])
 

--- a/tt_flash/chip.py
+++ b/tt_flash/chip.py
@@ -121,10 +121,12 @@ class TTChip:
         self.fw_defines = init_fw_defines(self)
 
         self.telmetry_cache = None
+        self.board_id_cache = None
 
     def reinit(self, callback=None):
         self.luwen_chip = PciChip(self.interface_id)
         self.telmetry_cache = None
+        self.board_id_cache = None
 
         chip_count = 0
         block_count = 0
@@ -206,7 +208,14 @@ class TTChip:
         return self.luwen_chip.pci_board_type()
 
     def board_id(self) -> int:
-        return PciChip(self.interface_id).board_id()
+        # Opening the PCI device again is what makes this readable on a chip
+        # whose firmware isn't answering, so the result is cached: callers ask
+        # more than once per chip, and two reads that disagree would be worse
+        # than one that is merely stale.
+        if self.board_id_cache is None:
+            self.board_id_cache = PciChip(self.interface_id).board_id()
+
+        return self.board_id_cache
 
     def axi_write32(self, addr: int, value: int):
         self.luwen_chip.axi_write32(addr, value)

--- a/tt_flash/chip.py
+++ b/tt_flash/chip.py
@@ -334,6 +334,36 @@ def resolve_board_type(dev: Union[WhChip, BhChip]) -> Optional[str]:
     return board_type
 
 
+def _asic_location(chip: BhChip) -> Optional[int]:
+    """
+    ASIC location of a chip, or None if it cannot be read.
+    """
+    try:
+        return chip.get_asic_location()
+    except Exception:
+        return None
+
+
+def _take_complement(pool: list[BhChip], chip: BhChip) -> Optional[BhChip]:
+    """
+    Remove and return the chip in pool that sits at the other ASIC location on
+    a card, or None when nothing in pool complements chip.
+
+    A P300 holds one ASIC at location 0 and one at location 1, so the only
+    chip in the pool that can be chip's sibling is one reporting the other
+    location. Any other choice pairs chips from different cards.
+    """
+    location = _asic_location(chip)
+    if location is None:
+        return None
+
+    for i, candidate in enumerate(pool):
+        if _asic_location(candidate) == 1 - location:
+            return pool.pop(i)
+
+    return None
+
+
 def validate_p300_can_be_flashed(
     devices: list[Union[WhChip, BhChip]],
 ) -> tuple[list[Union[WhChip, BhChip]], bool]:
@@ -345,8 +375,9 @@ def validate_p300_can_be_flashed(
 
     A chip running recovery firmware reports no board id and so cannot be
     grouped that way. It is still a chip that needs flashing -- that is how a
-    board gets out of recovery -- so pair it with the sibling that is missing
-    one, rather than leaving both halves of the card unflashed.
+    board gets out of recovery -- so pair it with a group that is missing one,
+    rather than leaving both halves of the card unflashed. Only a chip at the
+    other ASIC location can be that sibling; see _take_complement.
 
     Also verifies that the P300 board has exactly 1 chip with asic_location = 0 and exactly
     1 chip with asic_location = 1
@@ -378,12 +409,21 @@ def validate_p300_can_be_flashed(
     boards: list[tuple[Optional[int], list[BhChip]]] = []
     for board_id, chips in p300_groups.items():
         if len(chips) == 1 and unidentified:
-            chips.append(unidentified.pop())
+            sibling = _take_complement(unidentified, chips[0])
+            if sibling is not None:
+                chips.append(sibling)
         boards.append((board_id, chips))
 
-    # Cards with neither chip able to name its board.
+    # Cards with neither chip able to name its board. The board id that would
+    # group them is exactly what recovery firmware doesn't publish, so ASIC
+    # location is all there is to pair on.
     while len(unidentified) >= 2:
-        boards.append((None, [unidentified.pop(), unidentified.pop()]))
+        chip = unidentified.pop()
+        sibling = _take_complement(unidentified, chip)
+        if sibling is None:
+            unidentified.append(chip)
+            break
+        boards.append((None, [chip, sibling]))
     if unidentified:
         boards.append((None, list(unidentified)))
 

--- a/tt_flash/chip.py
+++ b/tt_flash/chip.py
@@ -311,6 +311,29 @@ class WhChip(TTChip):
         return get_bundle_version_v1(self)
 
 
+def resolve_board_type(dev: Union[WhChip, BhChip]) -> Optional[str]:
+    """
+    Board type of a chip, or None if nothing on the chip identifies it.
+
+    A chip running recovery firmware publishes no board id: board_id() either
+    raises or reads back as 0, which get_board_type does not recognize. Ask the
+    PCI device in that case. Its subsystem id carries the same UPI and does not
+    depend on what the chip is running.
+    """
+    try:
+        board_type = get_board_type(dev.board_id())
+    except Exception:
+        board_type = None
+
+    if board_type is None:
+        try:
+            board_type = get_board_type(dev.board_type(), from_type=True)
+        except Exception:
+            board_type = None
+
+    return board_type
+
+
 def validate_p300_can_be_flashed(
     devices: list[Union[WhChip, BhChip]],
 ) -> tuple[list[Union[WhChip, BhChip]], bool]:
@@ -320,50 +343,87 @@ def validate_p300_can_be_flashed(
 
     Groups P300 chips by board_id (assuming unique board IDs per card in a production context)
 
+    A chip running recovery firmware reports no board id and so cannot be
+    grouped that way. It is still a chip that needs flashing -- that is how a
+    board gets out of recovery -- so pair it with the sibling that is missing
+    one, rather than leaving both halves of the card unflashed.
+
     Also verifies that the P300 board has exactly 1 chip with asic_location = 0 and exactly
     1 chip with asic_location = 1
 
     Returns (filtered_devices, has_incomplete_p300)
     """
     p300_groups: dict[int, list[BhChip]] = defaultdict(list)
+    unidentified: list[BhChip] = []
     valid_devices: list[Union[WhChip, BhChip]] = []
 
     for dev in devices:
-        try:
-            board_id = dev.board_id()
-            board_type = get_board_type(board_id)
-        except Exception:
-            board_type = None
+        board_type = resolve_board_type(dev)
 
-        if board_type and "P300" in board_type:
-            p300_groups[board_id].append(dev)
-        else:
+        if not (board_type and "P300" in board_type):
             # only checking p300 validity so add all other devices to valid_devices
             valid_devices.append(dev)
+            continue
+
+        try:
+            board_id = dev.board_id()
+        except Exception:
+            board_id = 0
+
+        if board_id:
+            p300_groups[board_id].append(dev)
+        else:
+            unidentified.append(dev)
+
+    boards: list[tuple[Optional[int], list[BhChip]]] = []
+    for board_id, chips in p300_groups.items():
+        if len(chips) == 1 and unidentified:
+            chips.append(unidentified.pop())
+        boards.append((board_id, chips))
+
+    # Cards with neither chip able to name its board.
+    while len(unidentified) >= 2:
+        boards.append((None, [unidentified.pop(), unidentified.pop()]))
+    if unidentified:
+        boards.append((None, list(unidentified)))
 
     has_incomplete = False
 
-    for board_id, chips in p300_groups.items():
-        # Has 2 chips, but verify that ASIC locations are expected
-        if len(chips) == 2:
-            locations = {c.get_asic_location() for c in chips}
-            if locations == {0, 1}:
-                valid_devices.extend(chips)
-            else:
-                has_incomplete = True
-                print(
-                    CConfig.COLOR.RED,
-                    f"\tError: P300 board (board_id: {board_id:#x}) has 2 chips but both report ",
-                    f"the same ASIC location. Skipping flash for this board.",
-                    CConfig.COLOR.ENDC
-                )
+    for board_id, chips in boards:
+        board = f"board_id: {board_id:#x}" if board_id is not None else "no board id"
+
         # Doesn't have 2 chips
+        if len(chips) != 2:
+            has_incomplete = True
+            print(
+                CConfig.COLOR.RED,
+                f"\tError: P300 board ({board}) has {len(chips)} chip(s) detected,",
+                f"expected 2. Skipping flash for this board.",
+                CConfig.COLOR.ENDC
+            )
+            continue
+
+        # Has 2 chips, but verify that ASIC locations are expected
+        try:
+            locations = {c.get_asic_location() for c in chips}
+        except Exception as e:
+            has_incomplete = True
+            print(
+                CConfig.COLOR.RED,
+                f"\tError: P300 board ({board}) has 2 chips but their ASIC ",
+                f"locations could not be read ({e}). Skipping flash for this board.",
+                CConfig.COLOR.ENDC
+            )
+            continue
+
+        if locations == {0, 1}:
+            valid_devices.extend(chips)
         else:
             has_incomplete = True
             print(
                 CConfig.COLOR.RED,
-                f"\tError: P300 board (board_id: {board_id:#x}) has {len(chips)} chip(s) detected,",
-                f"expected 2. Skipping flash for this board.",
+                f"\tError: P300 board ({board}) has 2 chips but both report ",
+                f"the same ASIC location. Skipping flash for this board.",
                 CConfig.COLOR.ENDC
             )
 

--- a/tt_flash/flash.py
+++ b/tt_flash/flash.py
@@ -13,9 +13,9 @@ import random
 
 from tt_flash.blackhole import boot_fs_write, parse_writes_from_image
 from tt_flash.blackhole import FlashWrite
-from tt_flash.chip import BhChip, TTChip, WhChip, detect_chips
+from tt_flash.chip import BhChip, TTChip, WhChip, detect_chips, resolve_board_type
 from tt_flash.error import TTError
-from tt_flash.utility import change_to_public_name, get_board_type, CConfig
+from tt_flash.utility import change_to_public_name, CConfig
 from tt_flash.wormhole import (
     check_wh_can_reset,
     nebula_x2_post_flash,
@@ -107,6 +107,7 @@ def flash_chip_stage1(
     force: bool,
     allow_major_downgrades: bool,
     skip_missing_fw: bool = False,
+    update_boot_images: bool = False,
 ) -> FlashStageResult:
     """
     Check the chip and determine if it is a candidate to be flashed.
@@ -279,7 +280,9 @@ def flash_chip_stage1(
 
     if isinstance(chip, BhChip):
         writes = parse_writes_from_image(image)
-        writes = boot_fs_write(chip, boardname_to_display, mask, writes)
+        writes = boot_fs_write(
+            chip, boardname_to_display, mask, writes, update_boot_images
+        )
     else:
         writes = parse_wh_image(chip, boardname_to_display, image, mask)
 
@@ -541,6 +544,7 @@ def flash_chip(
     force: bool,
     allow_major_downgrades: bool,
     skip_missing_fw: bool = False,
+    update_boot_images: bool = False,
 ) -> FlashResult:
     """
     Flash firmware to a single chip. This function is process-safe and is intended to be called by
@@ -565,16 +569,9 @@ def flash_chip(
     # Reopen the tarfile in this process
     fw_package = tarfile.open(fwbundle, "r")
 
-    try:
-        boardname = get_board_type(pci_chip.board_id())
-    except:
-        # This exception can be thrown if board is running recovery FW.
-        # Fallback to a different detection method.
-        try:
-            boardname = get_board_type(dev.board_type(), from_type=True)
-        except:
-            boardname = None
-
+    # Falls back to the PCI subsystem id when the chip cannot name its own
+    # board, which is the case while it runs recovery FW.
+    boardname = resolve_board_type(dev)
 
     if boardname is None:
         raise TTError(f"Did not recognize board type for {dev}")
@@ -582,9 +579,10 @@ def flash_chip(
     # For p300 we need to check if its L or R chip
     if "P300" in boardname:
         # 0 = Right, 1 = Left
-        if dev.get_asic_location() == 0:
+        location = dev.get_asic_location()
+        if location == 0:
             boardname = f"{boardname}_right"
-        elif dev.get_asic_location() == 1:
+        elif location == 1:
             boardname = f"{boardname}_left"
 
     debug_messages.append(
@@ -609,6 +607,7 @@ def flash_chip(
         force,
         allow_major_downgrades,
         skip_missing_fw=skip_missing_fw,
+        update_boot_images=update_boot_images,
     )
 
     if result.state == FlashStageResultState.Err:

--- a/tt_flash/main.py
+++ b/tt_flash/main.py
@@ -124,7 +124,10 @@ def parse_args():
         required=False,
     )
     flash.add_argument(
-        "--force", default=False, action="store_true", help="Force update the ROM"
+        "--force",
+        default=False,
+        action="store_true",
+        help="Force update the ROM, bypassing the version and board checks that would otherwise stop the flash. This does not rewrite the bootloader and recovery images; pass --update-boot-images as well to do that",
     )
     flash.add_argument(
         "--no-reset",

--- a/tt_flash/main.py
+++ b/tt_flash/main.py
@@ -135,6 +135,12 @@ def parse_args():
     flash.add_argument(
         "--allow-major-downgrades", default=False, action="store_true", help="Allow major version downgrades"
     )
+    flash.add_argument(
+        "--update-boot-images",
+        default=False,
+        action="store_true",
+        help="Write the bundle's bootloader and recovery images even if the board already holds the same ones. They are left alone by default so that a power loss during an update cannot corrupt the board's boot path",
+    )
 
     verify = subparsers.add_parser(
         "verify",
@@ -292,7 +298,7 @@ def main():
             try:
                 # Run flash operations
                 flash_chip_args = [
-                    (dev.interface_id, fwbundle, manifest, args.force, args.allow_major_downgrades, args.skip_missing_fw)
+                    (dev.interface_id, fwbundle, manifest, args.force, args.allow_major_downgrades, args.skip_missing_fw, args.update_boot_images)
                     for dev in devices
                 ]
                 with Pool(initializer=pool_worker_init) as p:


### PR DESCRIPTION
Support not erasing the static table (which contains MCUBoot and Recovery images) by default, to ensure the chip's boot critical images aren't at risk of mid-update power loss.


Testing done by this firmware side PR that uses this branch of tt-flash: https://github.com/tenstorrent/tt-system-firmware/pull/1273