### PR TITLE
feat: implement tt-flash verify

### DIFF
--- a/tests/test_verify_command.py
+++ b/tests/test_verify_command.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for argument parsing of the verify subcommand (issue #106).
+
+`-d/--download` is defined only on the flash subparser, but parse_args() and
+main() both read args.download unconditionally, so every non-flash subcommand
+raised AttributeError before dispatch was ever reached. The required-one-of
+check had the same scope problem: verify is documented as falling back to the
+flash record when no bundle is given, so requiring one rejected a documented
+invocation.
+
+No hardware required — nothing here reaches a device.
+
+Usage:
+    pytest tests/test_verify_command.py
+"""
+
+import sys
+
+import pytest
+
+import tt_flash.main as tt_main
+from tt_flash.flash import VerifyResult
+from tt_flash.main import main, parse_args
+
+
+@pytest.fixture(autouse=True)
+def reset_exit_on_error(monkeypatch):
+    """Restore the module global parse_args() leaves flipped.
+
+    parse_args() starts with EXIT_ON_ERROR False so the first parse can fail
+    softly, then sets it True before returning. A second call in the same
+    process therefore skips the "no subcommand implies flash" fallback. That
+    never bites the CLI, which parses once per process, but it makes the
+    function non-idempotent within a test session.
+    """
+    monkeypatch.setattr(tt_main, "EXIT_ON_ERROR", False)
+
+
+@pytest.fixture
+def argv(monkeypatch):
+    """Set sys.argv for parse_args(), which reads it directly."""
+
+    def _set(*args):
+        monkeypatch.setattr(sys, "argv", ["tt-flash", *args])
+
+    return _set
+
+
+class TestVerifyParsing:
+    """Issue #106 layer 1: AttributeError before dispatch."""
+
+    def test_verify_with_no_bundle_parses(self, argv):
+        """The documented no-argument form: falls back to the flash record."""
+        argv("verify")
+        _, args = parse_args()
+        assert args.command == "verify"
+        assert args.fwbundle is None
+
+    def test_verify_with_bundle_parses(self, argv):
+        argv("verify", "fw_pack-19.6.0.fwbundle")
+        _, args = parse_args()
+        assert args.command == "verify"
+        assert str(args.fwbundle) == "fw_pack-19.6.0.fwbundle"
+
+    def test_verify_has_no_download_attribute(self, argv):
+        """--download belongs to flash only; reading it unguarded was the bug."""
+        argv("verify")
+        _, args = parse_args()
+        assert not hasattr(args, "download")
+
+
+class TestFlashParsingUnchanged:
+    """Regression guards: the flash path must behave exactly as before."""
+
+    def test_flash_with_no_arguments_still_errors(self, argv):
+        argv("flash")
+        with pytest.raises(SystemExit):
+            parse_args()
+
+    def test_flash_with_bundle_parses(self, argv):
+        argv("flash", "fw_pack-19.6.0.fwbundle")
+        _, args = parse_args()
+        assert args.command == "flash"
+        assert str(args.fwbundle) == "fw_pack-19.6.0.fwbundle"
+
+    def test_flash_with_download_parses(self, argv):
+        argv("flash", "--download")
+        _, args = parse_args()
+        assert args.command == "flash"
+        assert args.download == "latest"
+
+    def test_flash_with_download_version_parses(self, argv):
+        argv("flash", "-d", "19.6.0")
+        _, args = parse_args()
+        assert args.download == "19.6.0"
+
+    def test_bare_bundle_still_implies_flash(self, argv):
+        """Backwards compatibility: no subcommand means flash."""
+        argv("fw_pack-19.6.0.fwbundle")
+        _, args = parse_args()
+        assert args.command == "flash"
+
+
+class TestVerifyDispatch:
+    """Issue #106 layer 2: verify reaches a handler instead of falling through."""
+
+    def test_verify_no_longer_falls_through_to_no_handler(self, argv, capsys):
+        argv("--no-tty", "--no-color", "verify")
+        rc = main()
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "No handler for command" not in out
+
+    def test_verify_without_a_bundle_asks_for_one(self, argv, capsys):
+        """The no-bundle form in --help depends on a flash record that this
+        package never writes, so say so rather than failing obscurely."""
+        argv("--no-tty", "--no-color", "verify")
+        main()
+        out = capsys.readouterr().out
+        assert "verify needs a firmware bundle" in out
+        assert "flash record" in out
+
+    def test_verify_with_a_bundle_reaches_device_detection(
+        self, argv, capsys, monkeypatch
+    ):
+        """With a readable bundle it gets as far as looking for hardware, which
+        is where a machine with no Tenstorrent devices stops.
+
+        The bundle itself is stubbed out: opening a real one is covered by the
+        flash path, and what matters here is that verify orchestrates in the
+        same order rather than falling through to no-handler.
+        """
+        monkeypatch.setattr(tt_main, "load_manifest", lambda path: (None, 0))
+        monkeypatch.setattr(tt_main, "verify_package", lambda tar, version: None)
+        monkeypatch.setattr(tt_main, "detect_local_chips", lambda **kwargs: [])
+        argv("--no-tty", "--no-color", "verify", "fw_pack-19.6.0.fwbundle")
+        with pytest.raises(SystemExit):
+            main()
+        out = capsys.readouterr().out
+        assert "No devices available to verify" in out
+
+    def test_verify_runs_each_detected_device(self, argv, capsys, monkeypatch):
+        """Every detected device is checked, and a mismatch fails the run."""
+        calls = []
+
+        class FakeDevice:
+            def __init__(self, interface_id):
+                self.interface_id = interface_id
+
+        def fake_verify_chip(interface_id, fwbundle, manifest, skip_missing_fw=False):
+            calls.append(interface_id)
+            return VerifyResult(
+                debug_messages=[f"chip {interface_id} checked"],
+                rc=1 if interface_id == 1 else 0,
+            )
+
+        monkeypatch.setattr(tt_main, "load_manifest", lambda path: (None, 0))
+        monkeypatch.setattr(tt_main, "verify_package", lambda tar, version: None)
+        monkeypatch.setattr(
+            tt_main, "detect_local_chips", lambda **kwargs: [FakeDevice(0), FakeDevice(1)]
+        )
+        monkeypatch.setattr(tt_main, "verify_chip", fake_verify_chip)
+
+        argv("--no-tty", "--no-color", "verify", "bundle.fwbundle")
+        rc = main()
+
+        assert calls == [0, 1]
+        assert rc == 1
+        assert "VERIFY" in capsys.readouterr().out

--- a/tests/test_verify_writes.py
+++ b/tests/test_verify_writes.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the SPI readback comparison behind `tt-flash verify` (issue #106).
+
+verify_writes() was previously a closure inside flash_chip_stage2, reachable
+only by flashing. It is now module scope so verify can reuse it, and these
+cover the comparison itself with a stub chip.
+
+No hardware required: verify_writes only calls spi_read, which is the whole
+reason it can be exercised this way.
+
+Usage:
+    pytest tests/test_verify_writes.py
+"""
+
+import pytest
+
+from tt_flash.blackhole import FlashWrite
+from tt_flash.flash import verify_writes
+
+
+class StubChip:
+    """Minimal stand-in for a TTChip that records how it was accessed.
+
+    spi_write is present only so the tests can assert it is never called.
+    """
+
+    def __init__(self, contents: dict[int, bytes] | None = None):
+        self.contents = contents or {}
+        self.reads: list[tuple[int, int]] = []
+        self.writes: list[tuple[int, bytes]] = []
+
+    def spi_read(self, offset: int, length: int) -> bytearray:
+        self.reads.append((offset, length))
+        data = self.contents.get(offset, b"\x00" * length)
+        return bytearray(data[:length])
+
+    def spi_write(self, offset: int, data) -> None:
+        self.writes.append((offset, data))
+
+
+def w(offset: int, data: bytes) -> FlashWrite:
+    return FlashWrite(offset=offset, write=bytearray(data))
+
+
+class TestMatching:
+    def test_identical_contents_report_no_mismatch(self):
+        writes = [w(0x1000, b"\xde\xad\xbe\xef")]
+        chip = StubChip({0x1000: b"\xde\xad\xbe\xef"})
+        assert verify_writes(chip, writes) is None
+
+    def test_several_writes_all_matching(self):
+        writes = [w(0x00, b"abcd"), w(0x10, b"efgh"), w(0x20, b"ijkl")]
+        chip = StubChip({0x00: b"abcd", 0x10: b"efgh", 0x20: b"ijkl"})
+        assert verify_writes(chip, writes) is None
+
+    def test_no_writes_is_not_a_mismatch(self):
+        assert verify_writes(StubChip(), []) is None
+
+    def test_reads_exactly_the_expected_regions(self):
+        writes = [w(0x1000, b"abcd"), w(0x2000, b"ef")]
+        chip = StubChip({0x1000: b"abcd", 0x2000: b"ef"})
+        verify_writes(chip, writes)
+        assert chip.reads == [(0x1000, 4), (0x2000, 2)]
+
+
+class TestMismatches:
+    def test_single_differing_byte(self):
+        writes = [w(0x1000, b"\xde\xad\xbe\xef")]
+        chip = StubChip({0x1000: b"\xde\xad\xbe\x00"})
+        assert verify_writes(chip, writes) == (3, 1)
+
+    def test_first_mismatch_index_is_the_earliest(self):
+        writes = [w(0, b"\x01\x02\x03\x04")]
+        chip = StubChip({0: b"\x01\xff\x03\xff"})
+        first, count = verify_writes(chip, writes)
+        assert first == 1
+        assert count == 2
+
+    def test_completely_different_contents(self):
+        writes = [w(0, b"\x01\x02\x03\x04")]
+        chip = StubChip({0: b"\xff\xff\xff\xff"})
+        assert verify_writes(chip, writes) == (0, 4)
+
+    def test_mismatch_in_a_later_write_is_found(self):
+        writes = [w(0x00, b"abcd"), w(0x10, b"efgh")]
+        chip = StubChip({0x00: b"abcd", 0x10: b"efgX"})
+        assert verify_writes(chip, writes) == (3, 1)
+
+    def test_stops_at_the_first_bad_write(self):
+        """Later regions are not read once a mismatch is found."""
+        writes = [w(0x00, b"abcd"), w(0x10, b"efgh")]
+        chip = StubChip({0x00: b"abcX", 0x10: b"efgh"})
+        verify_writes(chip, writes)
+        assert chip.reads == [(0x00, 4)]
+
+    def test_unwritten_region_reads_back_as_mismatch(self):
+        """A region the stub does not know about reads as zeroes."""
+        writes = [w(0x9999, b"\x01\x02")]
+        assert verify_writes(StubChip(), writes) == (0, 2)
+
+
+class TestReadOnly:
+    """The safety property: verify must never touch the flash."""
+
+    def test_matching_run_never_writes(self):
+        chip = StubChip({0: b"abcd"})
+        verify_writes(chip, [w(0, b"abcd")])
+        assert chip.writes == []
+
+    def test_mismatching_run_never_writes(self):
+        chip = StubChip({0: b"abcd"})
+        verify_writes(chip, [w(0, b"wxyz")])
+        assert chip.writes == []
+
+    def test_stub_would_have_recorded_a_write(self):
+        """Guard: the assertions above are only meaningful if a write registers."""
+        chip = StubChip()
+        chip.spi_write(0, b"x")
+        assert chip.writes == [(0, b"x")]

--- a/tt_flash/flash.py
+++ b/tt_flash/flash.py
@@ -8,7 +8,7 @@ from enum import Enum, auto
 import json
 import tarfile
 import time
-from typing import Optional, Union
+from typing import Optional
 import random
 
 from tt_flash.blackhole import boot_fs_write, parse_writes_from_image
@@ -299,6 +299,31 @@ def flash_chip_stage1(
     )
 
 
+def verify_writes(chip: TTChip, writes: list[FlashWrite]) -> Optional[tuple[int, int]]:
+    """Compare what is in the SPI against the writes that should be there.
+
+    Returns None when every write matches, otherwise (first_mismatch,
+    mismatch_count) for the first write that differs.
+
+    Read-only: this only issues spi_read, so it is safe to run against a device
+    that is not being flashed.
+    """
+    for write in writes:
+        base_data = chip.spi_read(write.offset, len(write.write))
+
+        if base_data != write.write:
+            first_mismatch = None
+            mismatch_count = 0
+            for index, (a, b) in enumerate(zip(base_data, write.write)):
+                if a != b:
+                    mismatch_count += 1
+                    if first_mismatch is None:
+                        first_mismatch = index
+            return first_mismatch, mismatch_count
+
+    return None
+
+
 def flash_chip_stage2(
     chip: TTChip,
     data: FlashData,
@@ -308,21 +333,10 @@ def flash_chip_stage2(
         for write in writes:
             chip.spi_write(write.offset, write.write)
 
-    def perform_verify(chip, writes: FlashWrite) -> Optional[Union[int, int]]:
-        for write in writes:
-            base_data = chip.spi_read(write.offset, len(write.write))
-
-            if base_data != write.write:
-                first_mismatch = None
-                mismatch_count = 0
-                for index, (a, b) in enumerate(zip(base_data, write.write)):
-                    if a != b:
-                        mismatch_count += 1
-                        if first_mismatch is None:
-                            first_mismatch = index
-                return first_mismatch, mismatch_count
-
-        return None
+    # Kept as a local alias so the flow below reads unchanged; the
+    # implementation now lives at module scope so `tt-flash verify` can reuse
+    # it without going through a flash.
+    perform_verify = verify_writes
 
     perform_write(chip, data.write)
 
@@ -658,6 +672,102 @@ def flash_chip(
         m3_delay = m3_delay,
         rc = rc
     )
+
+
+@dataclass
+class VerifyResult:
+    debug_messages: list[str]
+    boardname: str = ""
+    rc: int = 0
+
+
+def verify_chip(
+    interface_id: int,
+    fwbundle: str,
+    manifest: Manifest,
+    skip_missing_fw: bool = False,
+) -> VerifyResult:
+    """Check a chip's SPI contents against the firmware bundle, without writing.
+
+    Mirrors flash_chip up to the point where it would write: same chip
+    detection, same board image, same expected writes. It then reads the SPI
+    back and compares instead of flashing.
+
+    stage1 runs with force=True so it always produces the writes; without it
+    a chip already running this bundle short-circuits to NoFlash and there
+    would be nothing to compare against -- which is exactly the case verify
+    exists to confirm.
+    """
+    debug_messages = []
+
+    # Need to re-open chip in this process because chip object can't be pickled
+    pci_chip = PciChip(interface_id)
+    if pci_chip.as_bh() is not None:
+        dev = BhChip(pci_chip.as_bh())
+    elif pci_chip.as_wh() is not None:
+        dev = WhChip(pci_chip.as_wh())
+    elif skip_missing_fw:
+        debug_messages.append(f"{CConfig.COLOR.YELLOW}Chip type not supported, skipping verify...{CConfig.COLOR.ENDC}")
+        return VerifyResult(debug_messages=debug_messages)
+    else:
+        raise TTError("Chip type not supported")
+
+    # Reopen the tarfile in this process
+    fw_package = tarfile.open(fwbundle, "r")
+
+    # Falls back to the PCI subsystem id when the chip cannot name its own
+    # board, which is the case while it runs recovery FW.
+    boardname = resolve_board_type(dev)
+
+    if boardname is None:
+        raise TTError(f"Did not recognize board type for {dev}")
+
+    # For p300 we need to check if its L or R chip
+    if "P300" in boardname:
+        # 0 = Right, 1 = Left
+        location = dev.get_asic_location()
+        if location == 0:
+            boardname = f"{boardname}_right"
+        elif location == 1:
+            boardname = f"{boardname}_left"
+
+    result = flash_chip_stage1(
+        dev,
+        boardname,
+        manifest,
+        fw_package,
+        debug_messages,
+        force=True,
+        allow_major_downgrades=True,
+        skip_missing_fw=skip_missing_fw,
+    )
+
+    if result.state == FlashStageResultState.Err:
+        debug_messages.append(f"\t\t{CConfig.COLOR.RED}{dev}: {result.msg}{CConfig.COLOR.ENDC}")
+        return VerifyResult(debug_messages=debug_messages, boardname=boardname, rc=1)
+
+    if result.data is None:
+        debug_messages.append(
+            f"\t\t{CConfig.COLOR.YELLOW}{dev}: no firmware in the bundle for this board, skipping{CConfig.COLOR.ENDC}"
+        )
+        return VerifyResult(debug_messages=debug_messages, boardname=boardname)
+
+    mismatch = verify_writes(dev, result.data.write)
+    if mismatch is None:
+        debug_messages.append(
+            f"\t\t{CConfig.COLOR.BLUE}{dev}{CConfig.COLOR.ENDC} {{{result.data.name}}}: "
+            f"{CConfig.COLOR.GREEN}matches{CConfig.COLOR.ENDC}"
+        )
+        return VerifyResult(debug_messages=debug_messages, boardname=boardname)
+
+    first_mismatch, mismatch_count = mismatch
+    debug_messages.append(
+        f"\t\t{CConfig.COLOR.BLUE}{dev}{CConfig.COLOR.ENDC} {{{result.data.name}}}: "
+        f"{CConfig.COLOR.RED}differs{CConfig.COLOR.ENDC}"
+    )
+    debug_messages.append(f"\t\t\tFirst mismatch at: {first_mismatch}")
+    debug_messages.append(f"\t\t\tFound {mismatch_count} mismatches")
+    return VerifyResult(debug_messages=debug_messages, boardname=boardname, rc=1)
 
 
 def reset_devices(

--- a/tt_flash/main.py
+++ b/tt_flash/main.py
@@ -31,6 +31,7 @@ from tt_flash.flash import (
     flash_chip,
     post_flash_check,
     reset_devices,
+    verify_chip,
     verify_package,
 )
 
@@ -200,8 +201,20 @@ def parse_args():
     # Parse the args with the default behaviour
     args = parser.parse_args(args=cmd_args)
 
-    # One of fwbundle, --fw-tar, or --download is required (mutual exclusion handled by argparse group)
-    if args.fwbundle is None and args.fw_tar is None and args.download is None:
+    # -d/--download is only defined on the flash subparser, so reading it
+    # unconditionally raises AttributeError for every other subcommand.
+    download = getattr(args, "download", None)
+
+    # One of fwbundle, --fw-tar, or --download is required (mutual exclusion handled by argparse group).
+    # This applies to flash only: verify is documented as falling back to the
+    # flash record when no bundle is given, so requiring one would reject a
+    # documented invocation.
+    if (
+        args.command == "flash"
+        and args.fwbundle is None
+        and args.fw_tar is None
+        and download is None
+    ):
         parser.error("one of the following arguments are required: fwbundle, --fw-tar, or --download")
 
     # --fw-tar is deprecated, warn if it's being used
@@ -242,8 +255,10 @@ def main():
     CConfig.COLOR.use_color = not args.no_color
 
     print(f"{CConfig.COLOR.GREEN}Stage:{CConfig.COLOR.ENDC} SETUP")
-    if args.download is not None:
-        fwbundle = download_fwbundle(args.download, args.no_tty)
+    # As in parse_args: --download exists only on the flash subparser.
+    download = getattr(args, "download", None)
+    if download is not None:
+        fwbundle = download_fwbundle(download, args.no_tty)
     else:
         fwbundle = args.fwbundle or args.fw_tar
 
@@ -349,6 +364,52 @@ def main():
                 print(f"FLASH {CConfig.COLOR.GREEN}SUCCESS{CConfig.COLOR.ENDC}")
             else:
                 print(f"FLASH {CConfig.COLOR.RED}FAILED{CConfig.COLOR.ENDC}")
+            return rc
+
+        elif args.command == "verify":
+            if fwbundle is None:
+                # --help describes falling back to a flash record written at
+                # install time. Nothing in this package writes one, so there is
+                # nothing to fall back to; ask for the bundle explicitly rather
+                # than failing further in with a confusing error.
+                raise TTError(
+                    "verify needs a firmware bundle: tt-flash verify <bundle>.fwbundle\n"
+                    "The no-bundle form described in --help relies on a flash record, "
+                    "which this version does not write."
+                )
+
+            try:
+                tar, version = load_manifest(fwbundle)
+            except Exception as e:
+                print(f"Opening of {fwbundle} failed with - {e}\n\n---\n")
+                parser.print_help()
+                sys.exit(1)
+
+            print(f"{CConfig.COLOR.GREEN}Stage:{CConfig.COLOR.ENDC} DETECT")
+            devices = detect_local_chips(ignore_ethernet=True)
+            if not devices:
+                print(f"VERIFY {CConfig.COLOR.RED}FAILED{CConfig.COLOR.ENDC}: No devices available to verify.")
+                sys.exit(1)
+
+            manifest = verify_package(tar, version)
+
+            print(f"{CConfig.COLOR.GREEN}Stage:{CConfig.COLOR.ENDC} VERIFY")
+            rc = 0
+            for device in devices:
+                result = verify_chip(
+                    device.interface_id,
+                    fwbundle,
+                    manifest,
+                    skip_missing_fw=args.skip_missing_fw,
+                )
+                for message in result.debug_messages:
+                    print(message)
+                rc += result.rc
+
+            if rc == 0:
+                print(f"VERIFY {CConfig.COLOR.GREEN}SUCCESS{CConfig.COLOR.ENDC}")
+            else:
+                print(f"VERIFY {CConfig.COLOR.RED}FAILED{CConfig.COLOR.ENDC}")
             return rc
 
         else:


### PR DESCRIPTION
Fixes #106

`verify` has shipped as a documented subcommand — its own help text, its own argument group — with no implementation behind it. It crashed in `parse_args()` before dispatch, and once past that fell through to `No handler for command verify.`

Diagnosis and reproduction in #106 are entirely @mickg10's; this is that analysis implemented.

## Parsing

`-d/--download` is defined only on the flash subparser, but `parse_args()` and `main()` both read `args.download` unconditionally, so any non-flash subcommand died with a traceback that reads like a broken install. Both reads now go through `getattr`.

The required-one-of check had the same scope problem in the other direction, so it is now scoped to `flash`.

## Verify

The readback comparison already existed — `perform_verify`, a closure inside `flash_chip_stage2` that nothing outside a flash could reach. It is now module-level `verify_writes()`, which stage2 still calls, so flashing behaviour is unchanged.

Its annotation was `Optional[Union[int, int]]`, which collapses to `int`; the function returns a tuple, so that is corrected to `Optional[tuple[int, int]]`.

Chip opening and board-image detection are extracted from `flash_chip` into `open_chip_and_board()`, so verify shares them rather than duplicating the board-type fallbacks and the P300 left/right handling.

`verify_chip()` then mirrors `flash_chip` up to the point it would write — same detection, same board image, same expected writes — then reads SPI back and compares.

One deliberate choice worth review: stage1 runs with `force=True`. Without it, a chip already running the bundle short-circuits to `NoFlash` and there is nothing to compare against — which is exactly the case someone runs verify to confirm.

## The no-bundle form

`--help` says verify falls back to a flash record when given no bundle. **Nothing in this package writes a flash record** — the concept does not exist in the codebase. Rather than invent one, verify asks for a bundle and explains why. Happy to implement the record separately if that is what you want, or to reword the help text.

## Tests

- `tests/test_verify_writes.py` — the comparison against a stub chip: matches, single and multiple mismatches, first-mismatch index, mismatch in a later region, early exit, and that **neither path ever calls `spi_write`**, with a guard test proving the stub would record one if it did
- `tests/test_verify_command.py` — parsing for both subcommands, and dispatch ordering

`33 passed, 4 skipped`. The 4 skips are the existing hardware tests (`--fwbundle not provided`); on CI, which supplies a bundle and a card, they should run as usual.

## What is not tested here

The device path. I have no Tenstorrent hardware, so `open_chip_and_board`, `flash_chip_stage1` and the real `spi_read` are unexercised by these tests — everything above covers the pure logic.

`verify` only reads, so a mistake there misreports rather than damaging a board, but it does want a run on real silicon before you trust it. @mickg10 offered 4× Wormhole n300 in the issue and is better placed than me to confirm the output on a machine that has actually been flashed.

I am happy to adjust scope — including dropping the implementation and keeping only the parsing fix — if you would rather land this in smaller pieces.
