### PR TITLE
Shadow flash tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,10 @@ env:
   # download works and no cross-repo token is needed.
   FW_REPO: tenstorrent/tt-system-firmware
   FW_VERSION: "19.13.2"
+  # Older bundle for the cross-major upgrade test. 18.x images are a single
+  # blob at offset 0 with boardcfg at 0xfff000, so upgrading to a 19.x image
+  # exercises the boardcfg relocation to 0xd4000.
+  FW_PREV_VERSION: "18.5.1"
 
 jobs:
   test-hardware-no-flash:
@@ -55,3 +59,44 @@ jobs:
           pytest tests/ -v \
             -m "requires_hardware and not flash and not shadow_flash" \
             --fwbundle "fw_pack-${FW_VERSION}.fwbundle"
+
+  test-shadow-flash:
+    name: Run Shadow Flash Tests (${{ matrix.runner }})
+    # Temporarily disabled. Re-enable by removing this `if`.
+    if: false
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          # Blackhole only: the shadow scaffolding is BH-specific.
+          - tt-ubuntu-2204-p150b-stable
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[test]"
+
+      - name: Download firmware bundles
+        run: |
+          for version in "${FW_VERSION}" "${FW_PREV_VERSION}"; do
+            curl -fsSL -O \
+              "https://github.com/${FW_REPO}/releases/download/v${version}/fw_pack-${version}.fwbundle"
+          done
+
+      # These write real bytes to SPI, but only into a scratch window well above
+      # the firmware layout -- see tests/bh_shadow.py.
+      - name: Run shadow flash tests
+        run: |
+          pytest tests/ -v -m shadow_flash \
+            --fwbundle "fw_pack-${FW_VERSION}.fwbundle" \
+            --fwbundle-prev "fw_pack-${FW_PREV_VERSION}.fwbundle"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,4 +46,4 @@ jobs:
 
       - name: Run hardware tests that don't perform flash
         run: |
-          pytest tests/ -v -m requires_hardware -m "not flash" --fwbundle tt-firmware/latest.fwbundle
+          pytest tests/ -v -m "requires_hardware and not flash" --fwbundle tt-firmware/latest.fwbundle

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,4 +52,6 @@ jobs:
 
       - name: Run hardware tests that don't perform flash
         run: |
-          pytest tests/ -v -m "requires_hardware and not flash" --fwbundle "fw_pack-${FW_VERSION}.fwbundle"
+          pytest tests/ -v \
+            -m "requires_hardware and not flash and not shadow_flash" \
+            --fwbundle "fw_pack-${FW_VERSION}.fwbundle"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,13 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  # Firmware comes from tt-system-firmware releases, which publish a combined
+  # fw_pack-<version>.fwbundle asset. The repo is public, so an unauthenticated
+  # download works and no cross-repo token is needed.
+  FW_REPO: tenstorrent/tt-system-firmware
+  FW_VERSION: "19.13.2"
+
 jobs:
   test-hardware-no-flash:
     name: Run Hardware Tests Without Flashing (${{ matrix.runner }})
@@ -28,12 +35,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          repository: tenstorrent/tt-firmware
-          path: tt-firmware
-
       - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
@@ -44,6 +45,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[test]"
 
+      - name: Download firmware bundle
+        run: |
+          curl -fsSL -O \
+            "https://github.com/${FW_REPO}/releases/download/v${FW_VERSION}/fw_pack-${FW_VERSION}.fwbundle"
+
       - name: Run hardware tests that don't perform flash
         run: |
-          pytest tests/ -v -m "requires_hardware and not flash" --fwbundle tt-firmware/latest.fwbundle
+          pytest tests/ -v -m "requires_hardware and not flash" --fwbundle "fw_pack-${FW_VERSION}.fwbundle"

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,18 @@ build:
 	. ./.env/bin/activate && python -m pip install --upgrade pip
 	. ./.env/bin/activate && python -m pip install --upgrade --ignore-installed -ve .[dev]
 
+# Build pyluwen from a local luwen checkout and install it over the published
+# wheel that `build` pulled in. Needed to pick up luwen changes that have not
+# been released yet; the force-reinstall has to come after `build`, or pip
+# resolves the dependency back to PyPI.
+.PHONY: local-luwen
+local-luwen:
+	. ./.env/bin/activate && python -m pip install maturin
+	. ./.env/bin/activate && maturin build --release \
+		-m ${LUWEN_DIR}/bind/pyluwen/Cargo.toml -o target/wheels
+	. ./.env/bin/activate && python -m pip install --force-reinstall \
+		--no-deps target/wheels/pyluwen-*.whl
+
 .PHONY: release
 release:
 	${PYTHON} -m venv my-env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ test = [
 markers = [
   "requires_hardware: marks tests as requiring Tenstorrent hardware",
   "flash: marks tests as flashing firmware Tenstorrent hardware",
+  "shadow_flash: marks tests as writing SPI in a scratch window, never the firmware region",
 ]
 
 [project.urls]

--- a/tests/bh_image.py
+++ b/tests/bh_image.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Helpers for reading, mutating and repacking Blackhole flash images.
+
+A Blackhole ``image.bin`` is an ASCII file of alternating ``@<decimal address>``
+lines and uppercase base16 data lines.  ``parse_writes_from_image`` turns that
+into absolute-addressed :class:`FlashWrite` objects; :func:`serialize_image` is
+its inverse, which lets tests mutate a real image and feed it back through the
+production flash path.
+"""
+
+import ctypes
+import io
+import json
+import tarfile
+from base64 import b16encode
+from typing import Iterator, Optional, Sequence
+
+from tt_flash import boot_fs
+from tt_flash.blackhole import FlashWrite, calculate_checksum, parse_writes_from_image
+
+FD_SIZE = ctypes.sizeof(boot_fs.tt_boot_fs_fd)
+SECTOR = 0x1000
+
+# The boot fs terminates the descriptor table on the first FD whose `invalid`
+# bit is set; erased flash (0xFF) reads as invalid, so 0xFF is the correct pad.
+ERASED = 0xFF
+
+
+def serialize_image(writes: Sequence[FlashWrite]) -> bytes:
+    """Inverse of :func:`parse_writes_from_image`."""
+    lines = []
+    for write in sorted(writes, key=lambda w: w.offset):
+        lines.append(f"@{write.offset}")
+        lines.append(b16encode(bytes(write.write)).decode("ascii"))
+    return ("\n".join(lines) + "\n").encode("ascii")
+
+
+def load_image(bundle_path: str, boardname: str) -> list[FlashWrite]:
+    """Read one board's image out of a fwbundle as FlashWrites."""
+    with tarfile.open(bundle_path, "r") as tar:
+        member = tar.extractfile(f"./{boardname}/image.bin")
+        if member is None:
+            raise LookupError(f"{bundle_path} has no ./{boardname}/image.bin")
+        return parse_writes_from_image(member.read())
+
+
+def head_write(writes: Sequence[FlashWrite]) -> FlashWrite:
+    """The FlashWrite carrying the boot fs descriptor table."""
+    for write in writes:
+        if write.offset == 0:
+            return write
+    raise LookupError("image has no descriptor table write at offset 0")
+
+
+def _reader(buf) -> "callable":
+    return lambda addr, size: bytes(buf[addr : addr + size])
+
+
+def iter_fds(buf) -> Iterator[tuple[int, boot_fs.tt_boot_fs_fd]]:
+    """Yield ``(byte offset, fd)`` for each valid FD in a descriptor table.
+
+    Bounded to one sector, which is all the table occupies on flash.
+    """
+    read = _reader(buf)
+    for offset in range(0, SECTOR, FD_SIZE):
+        fd = boot_fs.read_fd(read, offset)
+        if fd is None or fd.flags.f.invalid != 0:
+            return
+        yield offset, fd
+
+
+def find_tag(
+    writes: Sequence[FlashWrite], tag: str
+) -> Optional[tuple[FlashWrite, int, boot_fs.tt_boot_fs_fd]]:
+    """Locate ``tag`` in an image, returning (write, offset in write, fd)."""
+    for write in writes:
+        found = boot_fs.read_tag(_reader(write.write), tag)
+        if found is not None:
+            return write, found[0], found[1]
+    return None
+
+
+def body_write(
+    writes: Sequence[FlashWrite], fd: boot_fs.tt_boot_fs_fd
+) -> Optional[FlashWrite]:
+    """The write holding ``fd``'s body, matched the way the handlers match it.
+
+    Deliberately an exact-offset comparison, mirroring ``writeback_boardcfg``
+    and ``skip_ccfgovr``.  Returns None when the body is embedded inside a
+    larger write rather than starting one.
+    """
+    for write in writes:
+        if write.offset == fd.spi_addr:
+            return write
+    return None
+
+
+def seal_fd(fd: boot_fs.tt_boot_fs_fd) -> boot_fs.tt_boot_fs_fd:
+    """Recompute an FD's own checksum after mutating it."""
+    fd.fd_crc = 0
+    fd.fd_crc = calculate_checksum(bytes(fd)[:-4])
+    return fd
+
+
+def store_fd(buf, offset: int, fd: boot_fs.tt_boot_fs_fd) -> None:
+    """Write ``fd`` back into a descriptor table, resealing it first."""
+    buf[offset : offset + FD_SIZE] = bytes(seal_fd(fd))
+
+
+def drop_section(writes: Sequence[FlashWrite], offset: int) -> list[FlashWrite]:
+    """Remove the write starting at ``offset``, leaving its descriptor alone."""
+    return [write for write in writes if write.offset != offset]
+
+
+def embed_sections(
+    writes: Sequence[FlashWrite], addrs: Sequence[int], container_offset: int
+) -> list[FlashWrite]:
+    """Fold standalone body writes into one larger write starting earlier.
+
+    The bodies keep their addresses and contents, but no write *begins* at any
+    of them any more.  That is the shape which defeats the exact-offset
+    matching in ``skip_ccfgovr`` and ``writeback_boardcfg`` -- and a shape real
+    images already have elsewhere, since ``mainimg`` sits inside the write at
+    ``0x29d000`` rather than starting one.
+    """
+    bodies = {}
+    for addr in addrs:
+        match = [write for write in writes if write.offset == addr]
+        if not match:
+            raise LookupError(f"no write starts at 0x{addr:x}")
+        bodies[addr] = bytes(match[0].write)
+
+    if container_offset > min(bodies):
+        raise ValueError("container must start at or before the first body")
+    end = max(addr + len(data) for addr, data in bodies.items())
+
+    overlapping = [
+        write
+        for write in writes
+        if write.offset not in bodies and container_offset <= write.offset < end
+    ]
+    if overlapping:
+        raise ValueError(
+            f"container 0x{container_offset:x}..0x{end:x} would swallow "
+            f"{[hex(w.offset) for w in overlapping]}"
+        )
+
+    container = bytearray([ERASED]) * (end - container_offset)
+    for addr, data in bodies.items():
+        start = addr - container_offset
+        container[start : start + len(data)] = data
+
+    kept = [write for write in writes if write.offset not in bodies]
+    kept.append(FlashWrite(container_offset, container))
+    kept.sort(key=lambda w: w.offset)
+    return kept
+
+
+def write_fwbundle(
+    path: str,
+    boardname: str,
+    writes: Sequence[FlashWrite],
+    mask: list[dict],
+    manifest: dict,
+) -> str:
+    """Repack mutated writes into a minimal fwbundle tarball."""
+
+    def add(tar: tarfile.TarFile, name: str, payload: bytes) -> None:
+        info = tarfile.TarInfo(name)
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+
+    with tarfile.open(path, "w:gz") as tar:
+        add(tar, "./manifest.json", json.dumps(manifest).encode())
+        add(tar, f"./{boardname}/image.bin", serialize_image(writes))
+        add(tar, f"./{boardname}/mask.json", json.dumps(mask).encode())
+    return path
+
+
+def read_manifest(bundle_path: str) -> dict:
+    with tarfile.open(bundle_path, "r") as tar:
+        member = tar.extractfile("./manifest.json")
+        if member is None:
+            raise LookupError(f"{bundle_path} has no manifest")
+        return json.loads(member.read())
+
+
+def read_mask(bundle_path: str, boardname: str) -> list[dict]:
+    with tarfile.open(bundle_path, "r") as tar:
+        member = tar.extractfile(f"./{boardname}/mask.json")
+        if member is None:
+            raise LookupError(f"{bundle_path} has no ./{boardname}/mask.json")
+        return json.loads(member.read())

--- a/tests/bh_shadow.py
+++ b/tests/bh_shadow.py
@@ -1,0 +1,238 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Shadow-copy scaffolding for Blackhole SPI write tests.
+
+Blackhole flash is 64MB on every board, but the fixed partition layout ends
+below 0x32F000 and everything from 5MB up is the ``storage`` partition, which
+has no runtime consumer.  These helpers clone the live layout into a scratch
+window up there so tests can drive real erase and program cycles through the
+production flash path without ever touching the firmware region.
+"""
+
+import ctypes
+from typing import Iterator, Sequence
+
+import pytest
+
+import bh_image
+from tt_flash import boot_fs
+from tt_flash.blackhole import FlashWrite
+from tt_flash.chip import BhChip
+from tt_flash.utility import get_board_type
+
+SECTOR = 0x1000
+FLASH_SIZE = 0x4000000  # 64MB on every Blackhole board
+
+# Small shadow window, used by default.
+#
+# The base is chosen so its low 24 bits also land somewhere harmless.  Runtime
+# addressing is 4-byte (the SMC devicetree sets `use-4byte-addressing` and the
+# driver issues explicit 4-byte opcodes), so the real target is 40MB..48MB,
+# inside the unused `storage` partition.  But if a part ever truncated to 24
+# bits the window would fold to 8MB..16MB -- still `storage`, still nowhere
+# near the firmware.  A base of 0x2000000 would fold onto the descriptor table
+# at 0 and destroy the board; this one cannot, at any span up to 8MB.
+SHADOW_SMALL_BASE = 0x2800000
+SHADOW_SMALL_MAX_SPAN = 0x800000
+
+# Large shadow window, 32MB..64MB.  NOT fold-safe: under truncation it would
+# wrap through 0.  Only reachable once the truncation probe has actively ruled
+# that out.  Needed for 18.x-era images, which put boardcfg at 0xfff000.
+SHADOW_LARGE_BASE = 0x2000000
+SHADOW_LARGE_MAX_SPAN = 0x2000000
+
+FD_SIZE = ctypes.sizeof(boot_fs.tt_boot_fs_fd)
+
+_PROBE_MAGIC = bytes.fromhex("a5f0c3690f5a3c96") * 4
+_PROBE_CACHE: dict[int, bool] = {}
+
+
+def get_board_name(device) -> str:
+    """Board name used to select this device's image from a fwbundle."""
+    try:
+        boardname = get_board_type(device.board_type(), from_type=True)
+    except Exception:
+        boardname = pytest.fail(f"Board type not recognized for {device}")
+
+    # For P300 we need to check if it's L or R chip
+    if "P300" in boardname:
+        # 0 = Right, 1 = Left
+        if device.get_asic_location() == 0:
+            boardname = f"{boardname}_right"
+        elif device.get_asic_location() == 1:
+            boardname = f"{boardname}_left"
+
+    return boardname
+
+
+class ShadowChip(BhChip):
+    """A BhChip whose SPI accesses are relocated into a scratch window.
+
+    Subclasses BhChip rather than wrapping it because ``flash_chip_stage1``
+    dispatches on ``isinstance(chip, BhChip)``.  Everything downstream --
+    ``boot_fs.read_tag`` walking from address 0, ``writeback_boardcfg``,
+    ``skip_ccfgovr`` and stage 2's write/verify loop -- then lands in the
+    shadow with no production code change.
+
+    ``get_bundle_version`` is deliberately *not* redirected: it calls
+    ``decode_boot_fs_table`` inside pyluwen, which walks the boot fs at
+    absolute addresses.  Stage 1's version gate therefore sees the real flash,
+    so callers pass ``force=True``.
+    """
+
+    def __init__(self, chip: BhChip, base: int, span: int) -> None:
+        self.__dict__.update(chip.__dict__)  # reuse the live luwen handle
+        self._shadow_base = base
+        self._shadow_span = span
+
+    def __repr__(self) -> str:
+        return f"Shadow[{self.interface_id}]@0x{self._shadow_base:x}"
+
+    def _guard(self, addr: int, size: int) -> int:
+        assert addr >= 0 and size >= 0, f"negative shadow access {addr}+{size}"
+        phys = self._shadow_base + addr
+        assert phys + size <= self._shadow_base + self._shadow_span, (
+            f"shadow access escaped its window: 0x{phys:x}+{size} outside "
+            f"0x{self._shadow_base:x}..0x{self._shadow_base + self._shadow_span:x}"
+        )
+        return phys
+
+    def spi_read(self, addr: int, size: int) -> bytes:
+        return super().spi_read(self._guard(addr, size), size)
+
+    def spi_write(self, addr: int, data: bytes) -> None:
+        super().spi_write(self._guard(addr, len(data)), data)
+
+
+def on_chip_fds(chip) -> Iterator[tuple[int, boot_fs.tt_boot_fs_fd]]:
+    """Walk a chip's live boot fs descriptor table.
+
+    Bounded to one sector: that is all the table physically occupies, and an
+    unbounded walk over a region that is neither valid descriptors nor erased
+    flash would run until it happened to hit a set `invalid` bit.
+    """
+    for offset in range(0, SECTOR, FD_SIZE):
+        fd = boot_fs.read_fd(lambda a, s: chip.spi_read(a, s), offset)
+        if fd is None or fd.flags.f.invalid != 0:
+            return
+        yield offset, fd
+
+
+def sector_range(start: int, length: int) -> tuple[int, int]:
+    """Sector-aligned range covering ``length`` bytes at ``start``."""
+    return start & ~(SECTOR - 1), (start + length + SECTOR - 1) & ~(SECTOR - 1)
+
+
+def coalesce(regions: Sequence[tuple[int, int]]) -> list[tuple[int, int]]:
+    """Sort and merge overlapping or touching ranges."""
+    merged: list[tuple[int, int]] = []
+    for start, end in sorted(regions):
+        if end <= start:
+            continue
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def truncation_ok(chip: BhChip) -> bool:
+    """True if the part genuinely addresses above 16MB.
+
+    Writes a magic at the fold-safe small base and checks whether it also shows
+    up at that address truncated to 24 bits.  Both addresses sit in unused
+    ``storage``, so the probe is harmless whichever way it goes -- which is only
+    true *because* the small base is fold-safe.  Probing directly in the large
+    window would have destroyed the descriptor table before it could report
+    anything.
+    """
+    cached = _PROBE_CACHE.get(chip.interface_id)
+    if cached is not None:
+        return cached
+
+    fold = SHADOW_SMALL_BASE & 0xFFFFFF
+    chip.spi_write(fold, bytes(len(_PROBE_MAGIC)))
+    chip.spi_write(SHADOW_SMALL_BASE, _PROBE_MAGIC)
+    ok = chip.spi_read(fold, len(_PROBE_MAGIC)) != _PROBE_MAGIC
+
+    _PROBE_CACHE[chip.interface_id] = ok
+    return ok
+
+
+def required_span(chip: BhChip, writes: Sequence[FlashWrite] = ()) -> int:
+    """Highest SPI address the flash path will touch, rounded to a sector.
+
+    Covers three things: the live descriptor table and the bodies it points at,
+    the image's own write extents, and the addresses named by descriptors
+    *inside* the image.  That last one matters because ``writeback_boardcfg``
+    can append a write at an address no image section covers -- an 18.x image
+    is a single blob at 0 whose boardcfg descriptor points at 0xfff000.
+    """
+    end = SECTOR  # the descriptor table itself
+    for _, fd in on_chip_fds(chip):
+        end = max(end, fd.spi_addr + fd.flags.f.image_size)
+    for write in writes:
+        end = max(end, write.offset + len(write.write))
+        if write.offset == 0:
+            for _, fd in bh_image.iter_fds(write.write):
+                end = max(end, fd.spi_addr + fd.flags.f.image_size)
+    return (end + SECTOR - 1) & ~(SECTOR - 1)
+
+
+def clone_regions(chip: BhChip) -> list[tuple[int, int]]:
+    """Regions of live flash the shadow needs a faithful copy of.
+
+    Only the descriptor table and the bodies it points at, because those are
+    the only places the flash path reads from.  The dead space between
+    partitions is skipped, which keeps the clone near 1MB rather than 16MB.
+    """
+    regions = [(0, SECTOR)]
+    for _, fd in on_chip_fds(chip):
+        regions.append(sector_range(fd.spi_addr, fd.flags.f.image_size))
+    return coalesce(regions)
+
+
+def build_shadow(chip: BhChip, writes: Sequence[FlashWrite] = ()) -> ShadowChip:
+    """Pick a window, clone the live layout into it and verify the copy."""
+    span = required_span(chip, writes)
+
+    if span <= SHADOW_SMALL_MAX_SPAN:
+        base = SHADOW_SMALL_BASE
+    else:
+        if not truncation_ok(chip):
+            pytest.skip(
+                f"{chip} truncates SPI addresses to 24 bits; the large shadow "
+                "window would wrap onto the descriptor table"
+            )
+        if span > SHADOW_LARGE_MAX_SPAN:
+            pytest.skip(f"required span 0x{span:x} exceeds the large window")
+        base = SHADOW_LARGE_BASE
+
+    assert (
+        base + span <= FLASH_SIZE
+    ), f"shadow window 0x{base:x}+0x{span:x} runs off the end of flash"
+
+    shadow = ShadowChip(chip, base, span)
+    for start, end in clone_regions(chip):
+        if start >= span:
+            continue
+        end = min(end, span)
+        original = chip.spi_read(start, end - start)
+        shadow.spi_write(start, original)
+        assert (
+            shadow.spi_read(start, end - start) == original
+        ), f"shadow clone of 0x{start:x}..0x{end:x} did not read back"
+    return shadow
+
+
+def fill(chip, writes: Sequence[FlashWrite], value: int) -> None:
+    """Overwrite every write's extent with a constant byte.
+
+    Seeding with 0x00 before a flash is what makes the erase observable: NOR
+    programming can only clear bits, so a byte going from 0x00 to anything
+    non-zero cannot happen without a real sector erase.
+    """
+    for start, end in coalesce([(w.offset, w.offset + len(w.write)) for w in writes]):
+        chip.spi_write(start, bytes([value]) * (end - start))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,10 +5,12 @@
 Pytest configuration and fixtures for tt_flash tests.
 """
 
-from typing import Union
+from typing import Sequence, Union
 
 import pytest
 
+from bh_shadow import ShadowChip, build_shadow
+from tt_flash.blackhole import FlashWrite
 from tt_flash.chip import detect_chips, BhChip, WhChip
 
 
@@ -19,6 +21,12 @@ def pytest_addoption(parser):
         default=None,
         help="Path to firmware bundle (.fwbundle)",
     )
+    parser.addoption(
+        "--fwbundle-prev",
+        action="store",
+        default=None,
+        help="Path to an older firmware bundle, for cross-version flash tests",
+    )
 
 
 @pytest.fixture(scope="module")
@@ -27,6 +35,15 @@ def fwbundle_path(request):
     path = request.config.getoption("--fwbundle")
     if path is None:
         pytest.skip("--fwbundle not provided")
+    return path
+
+
+@pytest.fixture(scope="module")
+def prev_fwbundle_path(request):
+    """Get path to the older firmware bundle from pytest option."""
+    path = request.config.getoption("--fwbundle-prev")
+    if path is None:
+        pytest.skip("--fwbundle-prev not provided")
     return path
 
 
@@ -46,3 +63,13 @@ def bh_chips(devices: list[Union[WhChip, BhChip]]) -> list[BhChip]:
     if not bh_chips:
         pytest.skip("No BH devices detected on system")
     return bh_chips
+
+
+@pytest.fixture()
+def make_shadow():
+    """Factory building a verified ShadowChip for a chip and image."""
+
+    def _make(chip: BhChip, writes: Sequence[FlashWrite] = ()) -> ShadowChip:
+        return build_shadow(chip, writes)
+
+    return _make

--- a/tests/test_shadow_flash.py
+++ b/tests/test_shadow_flash.py
@@ -1,0 +1,417 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Blackhole SPI write tests driven against a shadow copy of the flash layout.
+
+These run the production flash path -- ``flash_chip_stage1`` then
+``flash_chip_stage2`` -- against a scratch window well above the firmware
+region, so every test performs real erase and program cycles and verifies by
+reading back from SPI.  The firmware region is only ever read.
+
+Why this is needed: re-flashing the same bundle is content-idempotent by
+construction (``writeback_boardcfg`` reads boardcfg off the chip and writes it
+straight back), and the SMC firmware's SpiSmartWrite is skip-if-identical, so a
+same-version reflash issues no erases and no programs at all.  A test built on
+that pattern passes even if erase and program are broken outright.  Seeding the
+shadow with known-wrong state first is what makes the write observable.
+
+Usage:
+    pytest test_shadow_flash.py --fwbundle=/path/to/bundle.fwbundle \
+        [--fwbundle-prev=/path/to/older.fwbundle]
+"""
+
+import pytest
+
+import bh_image as bi
+from bh_shadow import FD_SIZE, SECTOR, fill, get_board_name
+from tt_flash import boot_fs
+from tt_flash.blackhole import CCFGOVR_TAGS, calculate_checksum
+from tt_flash.flash import (
+    FlashStageResultState,
+    flash_chip_stage1,
+    flash_chip_stage2,
+    verify_package,
+)
+from tt_flash.main import load_manifest
+
+
+def bank_payload(seed: int, size: int) -> bytes:
+    return bytes((seed * 7 + i * 31) & 0xFF for i in range(size))
+
+
+def shipped_banks(image):
+    """The ccfgovr banks an image carries, as (tag, spi_addr, body length).
+
+    Bundles only started shipping these tags partway through the 19.x series,
+    so callers skip when the list comes back empty.
+    """
+    found = []
+    for tag in CCFGOVR_TAGS:
+        located = bi.find_tag(image, tag)
+        if located is not None:
+            found.append((tag, located[2].spi_addr, located[2].flags.f.image_size))
+    return found
+
+
+def seed_banks(shadow, banks) -> dict[int, bytes]:
+    """Put distinctive content in the shadow's ccfgovr banks.
+
+    Stands in for banks that tt-mod rewrote in the field: the firmware
+    validates them by a checksum in the bank header, not by the descriptor's
+    data_crc, so a flash must leave the bodies alone.
+    """
+    on_chip = {}
+    for index, (_, addr, size) in enumerate(banks):
+        on_chip[addr] = bank_payload(100 + index, size)
+        shadow.spi_write(addr, on_chip[addr])
+    return on_chip
+
+
+def stage1(chip, bundle_path, boardname, *, allow_major_downgrades=False):
+    """Compute the writes for a flash, reading existing state off `chip`."""
+    tar, version = load_manifest(bundle_path)
+    try:
+        manifest = verify_package(tar, version)
+        messages: list[str] = []
+        result = flash_chip_stage1(
+            chip,
+            boardname,
+            manifest,
+            tar,
+            messages,
+            True,  # force: stage 1's version gate reads the real chip, not the
+            # shadow, because get_bundle_version goes through pyluwen
+            allow_major_downgrades,
+        )
+    finally:
+        tar.close()
+    assert (
+        result.state == FlashStageResultState.Ok
+    ), f"stage 1 declined to flash: {result.state} {result.msg}"
+    return result.data, messages
+
+
+def flash_into_shadow(shadow, bundle_path, boardname, *, seed=None, **kwargs):
+    """Run a full flash against the shadow, optionally seeding it first.
+
+    Stage 1 runs *before* seeding on purpose: it reads the shadow's descriptor
+    table and boardcfg body, so scribbling over them first would just make it
+    fail.  Seeding between the stages means every byte stage 2 writes was the
+    seed value immediately beforehand.
+    """
+    data, messages = stage1(shadow, bundle_path, boardname, **kwargs)
+    if seed is not None:
+        fill(shadow, data.write, seed)
+    assert (
+        flash_chip_stage2(shadow, data, messages) is not None
+    ), "stage 2 failed:\n" + "\n".join(messages)
+    return data
+
+
+def read_back(shadow, writes) -> list[bytes]:
+    return [shadow.spi_read(w.offset, len(w.write)) for w in writes]
+
+
+def assert_flashed(shadow, writes) -> list[bytes]:
+    """Every write must be readable back from SPI byte for byte."""
+    got = read_back(shadow, writes)
+    for write, actual in zip(writes, got):
+        assert actual == bytes(write.write), (
+            f"readback mismatch at 0x{write.offset:x}: "
+            f"{len(write.write)} bytes intended, first differing byte at "
+            f"{next(i for i, (a, b) in enumerate(zip(actual, write.write)) if a != b)}"
+        )
+    return got
+
+
+def chip_tag(chip, tag):
+    """Locate a tag in a chip's live descriptor table."""
+    return boot_fs.read_tag(lambda addr, size: chip.spi_read(addr, size), tag)
+
+
+def seed_boardcfg(shadow) -> bytes:
+    """Put a distinctive boardcfg in the shadow and reseal its descriptor.
+
+    Stands in for the per-board identity data that a flash must preserve. The
+    descriptor's data_crc is recomputed so the seeded state is self-consistent,
+    which lets the test assert that the merge carried the metadata across too.
+    """
+    found = chip_tag(shadow, "boardcfg")
+    assert found is not None, "shadow has no boardcfg descriptor"
+    offset, fd = found
+
+    marker = bytes((0xA5 ^ (i * 13)) & 0xFF for i in range(fd.flags.f.image_size))
+    shadow.spi_write(fd.spi_addr, marker)
+
+    fd.data_crc = calculate_checksum(marker)
+    table = bytearray(shadow.spi_read(0, offset + FD_SIZE))
+    bi.store_fd(table, offset, fd)
+    shadow.spi_write(0, bytes(table))
+    return marker
+
+
+def repack(tmp_path, name, source_bundle, boardname, writes) -> str:
+    """Write mutated writes back out as a fwbundle stage 1 can consume."""
+    path = str(tmp_path / f"{name}-{boardname}.fwbundle")
+    return bi.write_fwbundle(
+        path,
+        boardname,
+        writes,
+        bi.read_mask(source_bundle, boardname),
+        bi.read_manifest(source_bundle),
+    )
+
+
+@pytest.mark.requires_hardware
+@pytest.mark.shadow_flash
+class TestShadowFlash:
+    def test_flash_erases_and_programs(self, bh_chips, fwbundle_path, make_shadow):
+        """
+        A flash must actually erase and program, not just appear to.
+
+        The shadow is filled with 0x00 immediately before stage 2 runs. NOR
+        programming can only clear bits, so a byte reading back as anything
+        non-zero cannot have got there without a real sector erase. That is the
+        assertion the existing same-version reflash test cannot make.
+        """
+        for chip in bh_chips:
+            boardname = get_board_name(chip)
+            image = bi.load_image(fwbundle_path, boardname)
+            shadow = make_shadow(chip, image)
+
+            data = flash_into_shadow(shadow, fwbundle_path, boardname, seed=0x00)
+            got = assert_flashed(shadow, data.write)
+
+            assert any(
+                byte for chunk in got for byte in chunk
+            ), "everything read back as zero, so no erase can have happened"
+
+    def test_reflash_is_idempotent(self, bh_chips, fwbundle_path, make_shadow):
+        """
+        Re-flashing identical content leaves the result correct.
+
+        This is the shape of the pre-existing test_flash_preserves_board_id, and
+        it passes here for the same reason it passes there: SpiSmartWrite
+        memcmps each sector and skips it when it already matches, so the second
+        flash touches the flash device not at all. Kept as an executable record
+        of why that pattern alone proves nothing.
+        """
+        for chip in bh_chips:
+            boardname = get_board_name(chip)
+            image = bi.load_image(fwbundle_path, boardname)
+            shadow = make_shadow(chip, image)
+
+            flash_into_shadow(shadow, fwbundle_path, boardname, seed=0x00)
+            data = flash_into_shadow(shadow, fwbundle_path, boardname)
+            assert_flashed(shadow, data.write)
+
+    def test_boardcfg_survives_flash(self, bh_chips, fwbundle_path, make_shadow):
+        """
+        Per-board identity data survives a genuine erase and program.
+
+        The image ships placeholder boardcfg; writeback_boardcfg must replace it
+        with what is already on the chip and repoint the descriptor. Here the
+        image has its own body write at the descriptor's address, so the handler
+        takes its overwrite branch.
+        """
+        for chip in bh_chips:
+            boardname = get_board_name(chip)
+            image = bi.load_image(fwbundle_path, boardname)
+            shadow = make_shadow(chip, image)
+
+            image_fd = bi.find_tag(image, "boardcfg")[2]
+            assert (
+                bi.body_write(image, image_fd) is not None
+            ), "expected the image to carry a boardcfg body write"
+
+            marker = seed_boardcfg(shadow)
+            data = flash_into_shadow(shadow, fwbundle_path, boardname)
+            assert_flashed(shadow, data.write)
+
+            assert (
+                shadow.spi_read(image_fd.spi_addr, len(marker)) == marker
+            ), "the chip's boardcfg was replaced by the image's placeholder"
+
+            _, fd = chip_tag(shadow, "boardcfg")
+            assert fd.spi_addr == image_fd.spi_addr
+            assert fd.flags.f.image_size == len(marker)
+            assert fd.data_crc == calculate_checksum(marker), "stale data_crc"
+            assert (
+                calculate_checksum(bytes(fd)[:-4]) == fd.fd_crc
+            ), "descriptor checksum does not validate"
+
+    def test_boardcfg_appended_when_image_has_no_body(
+        self, bh_chips, fwbundle_path, make_shadow, tmp_path
+    ):
+        """
+        writeback_boardcfg's other branch: no body write to overwrite.
+
+        Dropping the boardcfg section leaves its descriptor pointing at an
+        address no write starts, so the handler must append one. This is the
+        shape 18.x images have naturally, reproduced here inside the small
+        window.
+        """
+        for chip in bh_chips:
+            boardname = get_board_name(chip)
+            image = bi.load_image(fwbundle_path, boardname)
+            image_fd = bi.find_tag(image, "boardcfg")[2]
+
+            mutated = bi.drop_section(image, image_fd.spi_addr)
+            assert bi.body_write(mutated, image_fd) is None
+            bundle = repack(
+                tmp_path, "no-boardcfg-body", fwbundle_path, boardname, mutated
+            )
+
+            shadow = make_shadow(chip, mutated)
+            marker = seed_boardcfg(shadow)
+            data = flash_into_shadow(shadow, bundle, boardname)
+
+            assert any(
+                w.offset == image_fd.spi_addr for w in data.write
+            ), "handler did not append a boardcfg write"
+            assert_flashed(shadow, data.write)
+            assert shadow.spi_read(image_fd.spi_addr, len(marker)) == marker
+
+    def test_ccfgovr_banks_preserved(self, bh_chips, fwbundle_path, make_shadow):
+        """
+        On-chip ccfgovr banks survive a flash that ships its own copies.
+
+        The banks are field-updated by tt-mod, which cannot fix up the
+        descriptor's data_crc, so the firmware validates them by a checksum in
+        the bank header instead. tt-flash mirrors that by writing the descriptor
+        but dropping the body.
+        """
+        for chip in bh_chips:
+            boardname = get_board_name(chip)
+            image = bi.load_image(fwbundle_path, boardname)
+            banks = shipped_banks(image)
+            if not banks:
+                pytest.skip(f"{fwbundle_path} ships no ccfgovr banks for {boardname}")
+
+            shadow = make_shadow(chip, image)
+            on_chip = seed_banks(shadow, banks)
+            data = flash_into_shadow(shadow, fwbundle_path, boardname)
+
+            for tag, addr, size in banks:
+                assert not any(
+                    w.offset == addr for w in data.write
+                ), f"{tag} body write was not dropped"
+                assert (
+                    shadow.spi_read(addr, size) == on_chip[addr]
+                ), f"{tag} bank was overwritten by the image"
+
+                found = chip_tag(shadow, tag)
+                assert found is not None, f"{tag} descriptor was not written"
+                assert found[1].spi_addr == addr
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="skip_ccfgovr matches bodies by exact write offset, so a bank "
+        "embedded inside a larger write is not dropped and the on-chip "
+        "override is clobbered",
+    )
+    def test_embedded_ccfgovr_banks_preserved(
+        self, bh_chips, fwbundle_path, make_shadow, tmp_path
+    ):
+        """
+        The same preservation guarantee, when the bodies are not their own writes.
+
+        Both tag handlers locate a body by `write.offset == fd.spi_addr`, an
+        exact match. Real images already embed partitions inside larger sections
+        -- mainimg lives inside the write at 0x29d000 -- so an image generator
+        that emitted the ccfgovr banks that way would silently defeat the
+        preservation. This takes the banks the bundle really ships and folds
+        them into one larger write, leaving contents and addresses untouched.
+
+        Marked strict xfail: if it starts passing, the exact match has been
+        fixed and the marker should come off.
+        """
+        for chip in bh_chips:
+            boardname = get_board_name(chip)
+            image = bi.load_image(fwbundle_path, boardname)
+            banks = shipped_banks(image)
+            if not banks:
+                pytest.skip(f"{fwbundle_path} ships no ccfgovr banks for {boardname}")
+
+            addrs = [addr for _, addr, _ in banks]
+            embedded = bi.embed_sections(image, addrs, min(addrs) - SECTOR)
+            for _, addr, _ in banks:
+                assert not any(w.offset == addr for w in embedded)
+            bundle = repack(
+                tmp_path, "ccfgovr-embedded", fwbundle_path, boardname, embedded
+            )
+
+            shadow = make_shadow(chip, embedded)
+            on_chip = seed_banks(shadow, banks)
+            flash_into_shadow(shadow, bundle, boardname)
+
+            for tag, addr, size in banks:
+                assert (
+                    shadow.spi_read(addr, size) == on_chip[addr]
+                ), f"{tag} bank was overwritten by the image"
+
+    def test_cross_major_upgrade_migrates_boardcfg(
+        self, bh_chips, fwbundle_path, prev_fwbundle_path, make_shadow
+    ):
+        """
+        A real 18.x -> 19.x upgrade, including the boardcfg relocation.
+
+        18.x images are a single blob at 0 whose boardcfg descriptor points at
+        0xfff000; 19.x images are 20 sections with boardcfg at 0xd4000. Seeding
+        the shadow with the older layout and then flashing the newer one makes
+        writeback_boardcfg read boardcfg from the old address and repoint it at
+        the new one -- the genuine migration, against real flash.
+
+        Needs the large shadow window, so it skips unless the truncation probe
+        confirms addressing above 16MB really works.
+        """
+        for chip in bh_chips:
+            boardname = get_board_name(chip)
+            old_image = bi.load_image(prev_fwbundle_path, boardname)
+            new_image = bi.load_image(fwbundle_path, boardname)
+            shadow = make_shadow(chip, list(old_image) + list(new_image))
+
+            old_fd = bi.find_tag(old_image, "boardcfg")[2]
+            new_fd = bi.find_tag(new_image, "boardcfg")[2]
+            assert old_fd.spi_addr != new_fd.spi_addr, (
+                "bundles put boardcfg at the same address, so this test would "
+                "not exercise a migration"
+            )
+
+            # Lay down the older layout. The running chip is 19.x as far as
+            # stage 1 can tell, so this is a major downgrade from its point of
+            # view even though only the shadow is touched.
+            flash_into_shadow(
+                shadow,
+                prev_fwbundle_path,
+                boardname,
+                seed=0x00,
+                allow_major_downgrades=True,
+            )
+            migrated = chip_tag(shadow, "boardcfg")
+            assert migrated is not None
+            assert migrated[1].spi_addr == old_fd.spi_addr, "seed did not take"
+            before = shadow.spi_read(old_fd.spi_addr, migrated[1].flags.f.image_size)
+
+            # Now the upgrade under test.
+            data = flash_into_shadow(shadow, fwbundle_path, boardname)
+            assert_flashed(shadow, data.write)
+
+            _, fd = chip_tag(shadow, "boardcfg")
+            assert fd.spi_addr == new_fd.spi_addr, "boardcfg was not relocated"
+            assert (
+                shadow.spi_read(fd.spi_addr, len(before)) == before
+            ), "boardcfg content was lost in the move"
+
+            tags = {
+                t.image_tag_str()
+                for _, t in bi.iter_fds(bi.head_write(new_image).write)
+            }
+            on_shadow = set()
+            for offset in range(0, 0x1000, FD_SIZE):
+                found = boot_fs.read_fd(lambda a, s: shadow.spi_read(a, s), offset)
+                if found is None or found.flags.f.invalid != 0:
+                    break
+                on_shadow.add(found.image_tag_str())
+            assert tags <= on_shadow, f"missing tags after upgrade: {tags - on_shadow}"

--- a/tests/test_tag_handlers.py
+++ b/tests/test_tag_handlers.py
@@ -12,6 +12,7 @@ import tarfile
 
 import pytest
 
+from bh_shadow import get_board_name
 from tt_flash import boot_fs
 from tt_flash.blackhole import (
     CCFGOVR_TAGS,
@@ -20,26 +21,7 @@ from tt_flash.blackhole import (
     skip_ccfgovr,
     writeback_boardcfg,
 )
-from tt_flash.chip import BhChip, TTChip
-from tt_flash.utility import get_board_type
-
-
-def get_board_name(device: TTChip) -> str:
-    """Get board name for a device in order to grab the correct image from the fwbundle."""
-    try:
-        boardname = get_board_type(device.board_type(), from_type=True)
-    except:
-        boardname = pytest.fail(f"Board type not recognized for {device}")
-
-    # For P300 we need to check if it's L or R chip
-    if "P300" in boardname:
-        # 0 = Right, 1 = Left
-        if device.get_asic_location() == 0:
-            boardname = f"{boardname}_right"
-        elif device.get_asic_location() == 1:
-            boardname = f"{boardname}_left"
-
-    return boardname
+from tt_flash.chip import BhChip
 
 
 def bh_load_flash_writes_from_fwbundle(


### PR DESCRIPTION
Tests tt-flash on blackhole by using unused parts of the flash device as shadow flash space. This gives us meaningful end-to-end tests where the test can set up arbitrary existing SPI contents, run flash and then read the results from SPI.

Individual test cases were invented and written by AI. It considers one case to be buggy, which it marked expected-fail.
