### PR TITLE
Flash variable interlock

### DIFF
--- a/tests/test_compat_variables.py
+++ b/tests/test_compat_variables.py
@@ -1,0 +1,575 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for board variable evaluation. No hardware required.
+
+Usage:
+    pytest test_compat_variables.py
+"""
+
+import io
+import json
+import tarfile
+
+import pytest
+
+from tt_flash import compat_variables
+from tt_flash.compat_variables import CheckState, CompatVariables, describe_missing
+from tt_flash.error import TTError
+
+# TAG_FLASH_JEDEC_ID
+JEDEC_TAG = 80
+
+MT25 = 0x20BB20
+GD25 = 0xC8631A
+
+
+class FakeChip:
+    """A chip that reports the telemetry tags it was given."""
+
+    def __init__(self, telemetry: dict = None):
+        self.telemetry = telemetry if telemetry is not None else {}
+
+    def read_telemetry_tag(self, tag: int):
+        return self.telemetry.get(tag)
+
+
+def spi_eeprom(constraints: list, **overrides) -> dict:
+    variable = {
+        "name": "SPI EEPROM",
+        "number": 0,
+        "formatter": "hex",
+        "source": {"type": "telemetry", "tag": JEDEC_TAG},
+        "constraints": constraints,
+    }
+    variable.update(overrides)
+    return variable
+
+
+def compat(*variables, version: int = 1) -> CompatVariables:
+    return CompatVariables.loads(
+        json.dumps({"version": version, "variables": list(variables)})
+    )
+
+
+def test_constraint_satisfied():
+    verified, checks = compat_variables.evaluate(
+        FakeChip({JEDEC_TAG: GD25}),
+        compat(spi_eeprom([{"in": ["0x20bb20", "0xc8631a"]}])),
+    )
+
+    assert verified == 1
+    assert compat_variables.failed(checks) == []
+    assert [c.state for c in checks] == [CheckState.PASSED]
+    assert checks[0].message == ("SPI EEPROM is 0xc8631a, which this firmware supports")
+
+
+def test_constraint_violated():
+    verified, checks = compat_variables.evaluate(
+        FakeChip({JEDEC_TAG: GD25}), compat(spi_eeprom([{"eq": "0x20bb20"}]))
+    )
+
+    assert verified == 0
+    failures = compat_variables.failed(checks)
+    assert len(failures) == 1
+    assert failures[0].variable.number == 0
+    assert failures[0].value == GD25
+    assert failures[0].message == (
+        "SPI EEPROM is 0xc8631a; this firmware supports 0x20bb20"
+    )
+
+
+@pytest.mark.parametrize(
+    "constraints,value,expected",
+    [
+        ([{"eq": 4}], 4, True),
+        ([{"ne": 4}], 4, False),
+        ([{"lt": 4}], 3, True),
+        ([{"lt": 4}], 4, False),
+        ([{"le": 4}], 4, True),
+        ([{"gt": 4}], 5, True),
+        ([{"ge": 4}], 4, True),
+        ([{"in": [1, 2]}], 2, True),
+        ([{"not_in": [1, 2]}], 3, True),
+        # Every entry must hold
+        ([{"ge": 2}, {"lt": 4}], 3, True),
+        ([{"ge": 2}, {"lt": 4}], 4, False),
+        # A list can repeat an operator, which a map could not
+        ([{"ne": 1}, {"ne": 2}], 3, True),
+        ([{"ne": 1}, {"ne": 2}], 2, False),
+        # An empty list permits anything
+        ([], 99, True),
+    ],
+)
+def test_operators(constraints, value, expected):
+    verified, _ = compat_variables.evaluate(
+        FakeChip({JEDEC_TAG: value}), compat(spi_eeprom(constraints))
+    )
+
+    assert bool(verified & 1) is expected
+
+
+def test_values_may_be_decimal_or_hex():
+    verified, _ = compat_variables.evaluate(
+        FakeChip({JEDEC_TAG: MT25}), compat(spi_eeprom([{"eq": MT25}]))
+    )
+
+    assert verified == 1
+
+
+def test_unreadable_variable_is_unverified():
+    """
+    A board that does not report the tag leaves the variable unverified, and
+    says so rather than passing in silence.
+    """
+    verified, checks = compat_variables.evaluate(
+        FakeChip(), compat(spi_eeprom([{"eq": "0x20bb20"}]))
+    )
+
+    assert verified == 0
+    assert compat_variables.failed(checks) == []
+    assert [c.state for c in checks] == [CheckState.UNCHECKED]
+    assert checks[0].message == (
+        "SPI EEPROM could not be read from this board, so it was not checked"
+    )
+
+
+def test_unknown_source_is_unverified():
+    """Guessing at a retrieval method we don't know would defeat the check."""
+    verified, checks = compat_variables.evaluate(
+        FakeChip({JEDEC_TAG: MT25}),
+        compat(spi_eeprom([{"eq": "0x20bb20"}], source={"type": "dmc_message"})),
+    )
+
+    assert verified == 0
+    assert [c.state for c in checks] == [CheckState.UNCHECKED]
+
+
+def test_unknown_operator_is_unverified():
+    parsed = compat(spi_eeprom([{"between": [1, 2]}]))
+    verified, checks = compat_variables.evaluate(FakeChip({JEDEC_TAG: MT25}), parsed)
+
+    assert verified == 0
+    assert [c.state for c in checks] == [CheckState.UNCHECKED]
+    assert checks[0].message == (
+        "SPI EEPROM is constrained in a way this tt-flash does not understand, "
+        "so it was not checked"
+    )
+    assert parsed.unsupported
+
+
+def test_unknown_format_version_verifies_nothing():
+    """A format we don't know must not stop us flashing a board that needs none
+    of it, but must not let us claim we checked anything either."""
+    parsed = compat(spi_eeprom([{"eq": "0x20bb20"}]), version=99)
+    verified, checks = compat_variables.evaluate(FakeChip({JEDEC_TAG: MT25}), parsed)
+
+    assert verified == 0
+    assert checks == []
+    assert parsed.unsupported
+
+
+def test_malformed_value_is_an_error():
+    with pytest.raises(TTError):
+        compat(spi_eeprom([{"eq": "not a number"}]))
+
+
+@pytest.mark.parametrize(
+    "formatter,expected",
+    [
+        ("hex", "0x1020304"),
+        ("semver", "1.2.3"),
+        # An unknown or absent formatter falls back to hex, so a newer bundle
+        # never stops an older tt-flash from explaining itself
+        ("morse", "0x1020304"),
+        (None, "0x1020304"),
+    ],
+)
+def test_formatters(formatter, expected):
+    _, checks = compat_variables.evaluate(
+        FakeChip({JEDEC_TAG: 0x01020304}),
+        compat(spi_eeprom([{"eq": 0}], formatter=formatter)),
+    )
+
+    assert expected in checks[0].message
+
+
+def test_describe_constraint():
+    variable = compat(spi_eeprom([{"in": ["0x20bb20", "0xc8631a"]}])).variables[0]
+    assert variable.describe_constraint() == "one of 0x20bb20, 0xc8631a"
+
+    variable = compat(spi_eeprom([{"ge": 4}])).variables[0]
+    assert variable.describe_constraint() == "ge 0x4"
+
+
+def test_describe_missing_names_the_variable():
+    parsed = compat(spi_eeprom([{"eq": "0x20bb20"}]))
+    message = describe_missing(required=1, verified=0, compat=parsed)
+
+    assert "SPI EEPROM" in message
+
+
+def test_describe_missing_without_compat_variables():
+    """A bundle that predates board variables can't name them, so say so."""
+    message = describe_missing(required=1, verified=0, compat=None)
+
+    assert "board variable 0" in message
+    assert "newer bundle" in message
+
+
+def make_bundle(board: str, compat_variables_json=None) -> tarfile.TarFile:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        if compat_variables_json is not None:
+            data = json.dumps(compat_variables_json).encode("utf-8")
+            info = tarfile.TarInfo(f"./{board}/compat-variables.json")
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    buf.seek(0)
+    return tarfile.open(fileobj=buf, mode="r")
+
+
+def test_load_from_bundle():
+    bundle = make_bundle(
+        "P150A-1", {"version": 1, "variables": [spi_eeprom([{"eq": "0x20bb20"}])]}
+    )
+
+    parsed = compat_variables.load(bundle, "P150A-1")
+
+    assert parsed is not None
+    assert parsed.variables[0].name == "SPI EEPROM"
+
+
+def test_load_from_bundle_without_compat_variables():
+    """Bundles built before board variables existed declare nothing."""
+    parsed = compat_variables.load(make_bundle("P150A-1"), "P150A-1")
+
+    assert parsed is None
+
+    verified, checks = compat_variables.evaluate(FakeChip({JEDEC_TAG: GD25}), parsed)
+    assert verified == 0
+    assert checks == []
+
+
+def parse_flash_args(argv: list[str]):
+    """Parse a `tt-flash flash` command line."""
+    import sys
+
+    from tt_flash import main as tt_flash_main
+
+    argv_backup = sys.argv
+    sys.argv = ["tt-flash", "flash", "bundle.fwbundle"] + argv
+    try:
+        _, args = tt_flash_main.parse_args()
+    finally:
+        sys.argv = argv_backup
+    return args
+
+
+def test_force_does_not_bypass_variable_checks():
+    """
+    --force bypasses checks whose cost is a wasted flash. A board variable
+    mismatch costs the board, so it needs its own opt-in.
+    """
+    args = parse_flash_args(["--force"])
+
+    assert args.force
+    assert not args.force_all_variable_checks
+
+
+def test_force_all_variable_checks():
+    args = parse_flash_args(["--force-all-variable-checks"])
+
+    assert args.force_all_variable_checks
+    assert not args.force
+
+
+def test_force_all_variable_checks_defaults_off():
+    assert not parse_flash_args([]).force_all_variable_checks
+
+
+def test_force_all_variable_checks_is_hidden():
+    """It should not be advertised to someone reading --help."""
+    import io
+    import sys
+
+    from tt_flash import main as tt_flash_main
+
+    argv_backup = sys.argv
+    sys.argv = ["tt-flash", "flash", "bundle.fwbundle"]
+    try:
+        parser, _ = tt_flash_main.parse_args()
+    finally:
+        sys.argv = argv_backup
+
+    flash_parser = parser._subparsers._group_actions[0].choices["flash"]
+    help_text = io.StringIO()
+    flash_parser.print_help(help_text)
+
+    assert "--force-all-variable-checks" not in help_text.getvalue()
+    # ... though the parser really does accept it, and --force is still shown
+    assert "--force" in help_text.getvalue()
+    assert parse_flash_args(["--force-all-variable-checks"]).force_all_variable_checks
+
+
+# --- Driving flash_chip_stage1 with a real bundle -------------------------
+#
+# The checks above prove evaluate() reports a mismatch. These prove the
+# report survives the trip out of flash_chip_stage1 to the caller, which is
+# the part that decides whether anything is written.
+
+BOARDNAME = "P150A-1"
+
+# Two independent pointers into CSM, as the telemetry table publishes them
+SCRATCH_RAM = {12: 0x8003_0030, 13: 0x8003_0034}
+DATA_ADDR = 0x1000_1000
+TABLE_ADDR = 0x1000_2000
+
+
+class FakeLuwenChip:
+    """A Blackhole reporting one telemetry tag, and answering ARC messages."""
+
+    def __init__(self, jedec_id: int, unlock_response: list = None):
+        # What firmware answers FLASH_UNLOCK with; the default accepts it
+        self.unlock_response = unlock_response or [0] * 8
+        self.memory = {
+            SCRATCH_RAM[13]: TABLE_ADDR,
+            SCRATCH_RAM[12]: DATA_ADDR,
+            TABLE_ADDR: 1,
+            TABLE_ADDR + 4: 1,
+            TABLE_ADDR + 8: (0 << 16) | JEDEC_TAG,
+            DATA_ADDR: jedec_id,
+        }
+        self.messages = []
+        self.writes = []
+        # Messages and writes in the order they arrived, so a test can see
+        # which unlock a write rode on
+        self.events = []
+
+    def pci_interface_id(self) -> int:
+        return 0
+
+    def axi_translate(self, path: str):
+        import types
+
+        return types.SimpleNamespace(
+            addr=SCRATCH_RAM[int(path.split("[")[1].rstrip("]"))]
+        )
+
+    def axi_read32(self, addr: int) -> int:
+        return self.memory.get(addr, 0)
+
+    def axi_read(self, addr: int, data: bytearray):
+        for i in range(0, len(data), 4):
+            data[i : i + 4] = self.memory.get(addr + i, 0).to_bytes(4, "little")
+
+    def arc_msg_buf(self, buf, **kwargs):
+        code = buf[0] & 0xFF
+        self.messages.append(code)
+        match code:
+            case 0xC2:  # FLASH_UNLOCK
+                # Word 1 is what the host claims to have verified
+                self.events.append(("unlock", buf[1]))
+                return self.unlock_response
+            case 0xC3:  # FLASH_LOCK
+                self.events.append(("lock", None))
+                return [0] * 8
+            case _:
+                self.events.append(("msg", code))
+                return [0] * 8
+
+    def spi_write(self, addr: int, data: bytes):
+        self.writes.append((addr, bytes(data)))
+        self.events.append(("write", addr))
+        # luwen locks the flash again after each write it performs
+        self.arc_msg_buf([0xC3, 0, 0, 0, 0, 0, 0, 0])
+
+    def arc_msg(self, *args, **kwargs):
+        return (0, 0)
+
+
+def stage1_bundle(constraints: list) -> "tarfile.TarFile":
+    """A bundle holding the three files stage 1 reads for a board."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+
+        def add(name: str, payload: bytes):
+            info = tarfile.TarInfo(f"./{BOARDNAME}/{name}")
+            info.size = len(payload)
+            tar.addfile(info, io.BytesIO(payload))
+
+        add("image.bin", b"00")
+        add("mask.json", json.dumps([]).encode())
+        add(
+            "compat-variables.json",
+            json.dumps({"version": 1, "variables": [spi_eeprom(constraints)]}).encode(),
+        )
+    buf.seek(0)
+    return tarfile.open(fileobj=buf, mode="r")
+
+
+@pytest.fixture()
+def stage1(monkeypatch):
+    """
+    flash_chip_stage1 with the image parsing stubbed out: these tests are
+    about the compatibility gate, not about what would have been written.
+    """
+    from tt_flash import flash as tt_flash_flash
+    from tt_flash.chip import BhChip, FwVersion
+
+    monkeypatch.setattr(tt_flash_flash, "parse_writes_from_image", lambda image: [])
+    monkeypatch.setattr(tt_flash_flash, "boot_fs_write", lambda *args, **kwargs: [])
+
+    def run(jedec_id: int, constraints: list, unlock_response: list = None, **kwargs):
+        chip = BhChip(FakeLuwenChip(jedec_id, unlock_response))
+        # Kept so a test whose call raises can still look at the chip
+        run.chip = chip
+        monkeypatch.setattr(
+            chip,
+            "get_bundle_version",
+            lambda: FwVersion(
+                allow_exception=False,
+                exception=None,
+                running=(19, 14, 99, 0),
+                spi=(19, 14, 99, 0),
+            ),
+        )
+        manifest = tt_flash_flash.Manifest(data={}, bundle_version=(19, 14, 100, 0))
+        debug_messages = []
+        result = tt_flash_flash.flash_chip_stage1(
+            chip,
+            BOARDNAME,
+            manifest,
+            stage1_bundle(constraints),
+            debug_messages,
+            force=False,
+            allow_major_downgrades=False,
+            **kwargs,
+        )
+        return chip, result, debug_messages
+
+    return run
+
+
+def test_stage1_refuses_a_mismatching_bundle(stage1):
+    """
+    The bundle that started this: a board reporting 0x20bb20 against an image
+    that says it supports only 0x4220bb20. The refusal must reach the caller,
+    not be swallowed into a result nobody reads.
+    """
+    with pytest.raises(TTError) as refusal:
+        stage1(0x20BB20, [{"eq": "0x4220bb20"}])
+
+    assert "not compatible with this board" in str(refusal.value)
+    assert "SPI EEPROM is 0x20bb20" in str(refusal.value)
+
+
+def test_stage1_accepts_a_matching_bundle(stage1):
+    chip, result, debug_messages = stage1(0x20BB20, [{"eq": "0x20bb20"}])
+
+    assert result.state.name == "Ok"
+    assert chip.verified_variables == 1
+    # The board was asked, and put back the way it was found
+    assert chip.luwen_chip.messages == [0xC2, 0xC3]
+
+
+def test_stage1_reports_every_variable_it_checked(stage1):
+    _, _, debug_messages = stage1(0x20BB20, [{"eq": "0x20bb20"}])
+
+    assert any(
+        "SPI EEPROM is 0x20bb20, which this firmware supports" in message
+        for message in debug_messages
+    )
+
+
+def test_stage1_says_when_a_bundle_declares_nothing(stage1, monkeypatch):
+    """
+    A bundle with no compatibility data must not look like one whose checks
+    all passed.
+    """
+    from tt_flash import compat_variables as cv
+
+    monkeypatch.setattr(cv, "load", lambda fw_package, boardname: None)
+
+    _, result, debug_messages = stage1(0x20BB20, [{"eq": "0x20bb20"}])
+
+    assert result.state.name == "Ok"
+    assert any("does not say which hardware it supports" in m for m in debug_messages)
+
+
+def test_stage1_refuses_when_firmware_demands_more(stage1):
+    """
+    Firmware can require a variable this tt-flash did not verify. It refuses
+    the unlock, and that refusal has to stop the flash before any write.
+    """
+    # Status 1, requiring variables 0 and 1. We verified 0; nothing in the
+    # bundle describes 1, so we cannot verify it.
+    with pytest.raises(TTError) as refusal:
+        stage1(
+            0x20BB20,
+            [{"eq": "0x20bb20"}],
+            unlock_response=[1, 0b11, 0, 0, 0, 0, 0, 0],
+        )
+
+    assert "will not allow a flash until these are verified" in str(refusal.value)
+    assert "board variable 1" in str(refusal.value)
+    # Only the variable we could not verify is named
+    assert "SPI EEPROM" not in str(refusal.value)
+
+    chip = stage1.chip
+    assert chip.luwen_chip.writes == []
+    # Refused or not, the board is left locked
+    assert chip.luwen_chip.messages == [0xC2, 0xC3]
+
+
+def test_stage1_mismatch_can_be_forced(stage1):
+    chip, result, debug_messages = stage1(
+        0x20BB20, [{"eq": "0x4220bb20"}], force_all_variable_checks=True
+    )
+
+    assert result.state.name == "Ok"
+    # Forced, so firmware is told the check was made, or it would refuse
+    assert chip.verified_variables == 1
+    assert any("--force-all-variable-checks" in m for m in debug_messages)
+
+
+def test_every_spi_write_declares_the_variables():
+    """
+    luwen locks the flash again after each write it performs, which withdraws
+    firmware's record of what we verified. A write that is not preceded by its
+    own unlock would be refused, so a multi-write flash has to re-declare
+    before each one.
+    """
+    from tt_flash.chip import BhChip
+
+    chip = BhChip(FakeLuwenChip(0x20BB20))
+    chip.verified_variables = 0b101
+
+    chip.spi_write(0, b"aaaa")
+    chip.spi_write(4, b"bbbb")
+
+    assert chip.luwen_chip.events == [
+        ("unlock", 0b101),
+        ("write", 0),
+        ("lock", None),
+        ("unlock", 0b101),
+        ("write", 4),
+        ("lock", None),
+    ]
+
+
+def test_writes_declare_what_stage1_verified(stage1):
+    """
+    The declaration a write carries is the result of stage 1's checks, and it
+    has to survive the lock stage 1 leaves the board in.
+    """
+    chip, result, _ = stage1(0x20BB20, [{"eq": "0x20bb20"}])
+
+    chip.spi_write(0x1000, b"aaaa")
+
+    assert chip.luwen_chip.events[-3:] == [
+        ("unlock", 1),
+        ("write", 0x1000),
+        ("lock", None),
+    ]

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for reading telemetry by tag. No hardware required.
+
+Usage:
+    pytest test_telemetry.py
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from tt_flash.chip import BhChip
+
+# Two independent pointers into CSM. The data array is deliberately placed
+# below the table here, so that anything deriving one address from the other
+# reads the wrong words.
+SCRATCH_RAM = {12: 0x8003_0030, 13: 0x8003_0034}
+DATA_ADDR = 0x1000_1000
+TABLE_ADDR = 0x1000_2000
+
+
+class FakeLuwenChip:
+    """Enough of a Blackhole chip to serve reads out of a sparse memory."""
+
+    def __init__(self, memory: dict[int, int]):
+        self.memory = memory
+
+    def pci_interface_id(self) -> int:
+        return 0
+
+    def axi_translate(self, path: str) -> SimpleNamespace:
+        index = int(path.split("[")[1].rstrip("]"))
+        return SimpleNamespace(addr=SCRATCH_RAM[index])
+
+    def axi_read32(self, addr: int) -> int:
+        return self.memory.get(addr, 0)
+
+    def axi_read(self, addr: int, data: bytearray):
+        for i in range(0, len(data), 4):
+            data[i : i + 4] = self.memory.get(addr + i, 0).to_bytes(4, "little")
+
+
+def telemetry_memory(entries: dict[int, int], values: dict[int, int]) -> dict[int, int]:
+    """
+    Lays out a telemetry table: entries maps tag -> offset, values maps
+    offset -> the word at that offset in the data array.
+    """
+    memory = {
+        SCRATCH_RAM[13]: TABLE_ADDR,
+        SCRATCH_RAM[12]: DATA_ADDR,
+        TABLE_ADDR: 1,  # version
+        TABLE_ADDR + 4: len(entries),
+    }
+    for i, (tag, offset) in enumerate(entries.items()):
+        memory[TABLE_ADDR + 8 + i * 4] = (offset << 16) | tag
+    for offset, value in values.items():
+        memory[DATA_ADDR + offset * 4] = value
+    return memory
+
+
+def chip(memory: dict[int, int]) -> BhChip:
+    return BhChip(FakeLuwenChip(memory))
+
+
+def test_read_telemetry_tag():
+    device = chip(telemetry_memory({80: 5, 1: 0}, {5: 0x20BB20, 0: 0xDEADBEEF}))
+
+    assert device.read_telemetry_tag(80) == 0x20BB20
+    assert device.read_telemetry_tag(1) == 0xDEADBEEF
+
+
+def test_unreported_tag():
+    device = chip(telemetry_memory({1: 0}, {0: 0xDEADBEEF}))
+
+    assert device.read_telemetry_tag(80) is None
+
+
+def test_data_array_is_not_relative_to_the_table():
+    """
+    The data array has its own pointer and may sit anywhere; a reader that
+    assumes it follows the tag table reads the wrong words, or nothing.
+    """
+    entries = {80: 5}
+    memory = telemetry_memory(entries, {5: 0x20BB20})
+    # What a reader deriving the data address from the table would land on
+    table_relative = TABLE_ADDR + 8 + len(entries) * 4
+    memory[table_relative + 5 * 4] = 0xBADBAD
+
+    assert chip(memory).read_telemetry_tag(80) == 0x20BB20
+
+
+def test_offset_beyond_the_entry_count():
+    """
+    The data array's length is not the entry count; an offset may point past
+    it.
+    """
+    device = chip(telemetry_memory({80: 9}, {9: 0x20BB20}))
+
+    assert device.read_telemetry_tag(80) == 0x20BB20
+
+
+def test_table_is_cached():
+    memory = telemetry_memory({80: 0}, {0: 0x20BB20})
+    device = chip(memory)
+
+    assert device.read_telemetry_tag(80) == 0x20BB20
+
+    memory.clear()  # A second walk of the table would now fail
+    assert device.read_telemetry_tag(80) == 0x20BB20
+
+
+@pytest.mark.parametrize(
+    "broken",
+    [
+        {SCRATCH_RAM[13]: 0},  # firmware has not published the table
+        {SCRATCH_RAM[12]: 0},  # nor the data array
+        {SCRATCH_RAM[13]: 0xFFFFFFFF},  # a pointer outside CSM
+        {TABLE_ADDR + 4: 0},  # no entries
+        {TABLE_ADDR + 4: 0xFFFFFFFF},  # an entry count that cannot be real
+    ],
+)
+def test_unreadable_telemetry(broken):
+    """A chip that cannot tell us reports no tags, rather than throwing."""
+    memory = telemetry_memory({80: 0}, {0: 0x20BB20})
+    memory.update(broken)
+
+    assert chip(memory).read_telemetry_tag(80) is None

--- a/tt_flash/chip.py
+++ b/tt_flash/chip.py
@@ -17,6 +17,7 @@ from pyluwen import detect_chips_fallible as luwen_detect_chips_fallible
 from collections import defaultdict
 
 from tt_flash import utility
+from tt_flash.compat_variables import CompatVariables, describe_missing
 from tt_flash.error import TTError
 from tt_flash.utility import CConfig, get_board_type
 
@@ -253,6 +254,10 @@ class TTChip:
         pass
 
 
+# Blackhole message codes, from include/tenstorrent/smc_msg.h
+MSG_FLASH_UNLOCK = 0xC2
+MSG_FLASH_LOCK = 0xC3
+
 # Telemetry lives in CSM; an address outside it means we did not find the table
 CSM_RANGE = range(0x10000000, 0x10080000)
 
@@ -265,6 +270,11 @@ class BhChip(TTChip):
     def __init__(self, chip: PciChip):
         super().__init__(chip)
 
+        # The board variables verified against the image about to be written.
+        # Zero until stage 1 has checked them, so a write that skips that check
+        # fails closed on a board that requires any.
+        self.verified_variables = 0
+        self.compat_variables: Optional[CompatVariables] = None
         self.telemetry_tag_cache = None
 
     def min_fw_version(self):
@@ -371,6 +381,51 @@ class BhChip(TTChip):
             tag: int.from_bytes(values[offset * 4 : offset * 4 + 4], "little")
             for tag, offset in offsets.items()
         }
+
+    def flash_unlock(self):
+        """
+        Unlocks the flash for writing, declaring the board variables we
+        verified against the image.
+
+        Firmware remembers the declaration until the next lock, so luwen's own
+        bare unlock inside spi_write rides on this one.
+        """
+
+        # Word 0 carries the message code and the number of variable words that
+        # follow; luwen overwrites only the code's byte.
+        try:
+            response = self.luwen_chip.arc_msg_buf(
+                [MSG_FLASH_UNLOCK | (1 << 8), self.verified_variables, 0, 0, 0, 0, 0, 0]
+            )
+        except Exception:
+            # Firmware too old to answer the message at all. luwen's own unlock
+            # ignores this as well; a flash that really is locked then fails at
+            # the write rather than here.
+            return
+
+        if response is None:
+            return
+
+        status = response[0] & 0xFF
+        required = response[1]
+        if status != 0:
+            raise TTError(
+                describe_missing(
+                    required, self.verified_variables, self.compat_variables
+                )
+            )
+
+    def flash_lock(self):
+        try:
+            self.luwen_chip.arc_msg_buf([MSG_FLASH_LOCK, 0, 0, 0, 0, 0, 0, 0])
+        except Exception:
+            pass
+
+    def spi_write(self, addr: int, data: bytes):
+        # luwen re-locks the flash after every write, which withdraws the
+        # firmware's record of what we verified, so declare it again each time.
+        self.flash_unlock()
+        super().spi_write(addr, data)
 
     def get_asic_location(self) -> int:
         """

--- a/tt_flash/chip.py
+++ b/tt_flash/chip.py
@@ -253,7 +253,20 @@ class TTChip:
         pass
 
 
+# Telemetry lives in CSM; an address outside it means we did not find the table
+CSM_RANGE = range(0x10000000, 0x10080000)
+
+# A sanity bound on the entry count read off the chip, so that a garbage value
+# cannot turn into an enormous read
+MAX_TELEMETRY_ENTRIES = 4096
+
+
 class BhChip(TTChip):
+    def __init__(self, chip: PciChip):
+        super().__init__(chip)
+
+        self.telemetry_tag_cache = None
+
     def min_fw_version(self):
         return 0x0
 
@@ -288,6 +301,76 @@ class BhChip(TTChip):
         return FwVersion(
             allow_exception=True, exception=exception, running=running, spi=spi
         )
+
+    def read_telemetry_tag(self, tag: int) -> Optional[int]:
+        """
+        Reads one telemetry tag by number.
+
+        luwen's get_telemetry() demultiplexes the table into a fixed struct and
+        drops any tag it was not built to know about, so board variables read
+        the table directly. That also means a firmware that starts reporting a
+        new tag needs no change here.
+        """
+
+        if self.telemetry_tag_cache is None:
+            self.telemetry_tag_cache = self.__read_telemetry_table()
+
+        return self.telemetry_tag_cache.get(tag)
+
+    def __scratch_ram(self, index: int) -> int:
+        return self.luwen_chip.axi_translate(
+            f"arc_ss.reset_unit.SCRATCH_RAM[{index}]"
+        ).addr
+
+    def __read_telemetry_table(self) -> dict[int, int]:
+        """
+        Reads the whole telemetry table into a tag to value map.
+
+        The table and the data array are published as two independent
+        pointers, and a tag entry's offset indexes the data array. Nothing may
+        be assumed about where the two sit relative to each other.
+
+            struct telemetry_entry { uint16_t tag; uint16_t offset; };
+
+            struct telemetry_table {        // SCRATCH_RAM[13] points here
+                    uint32_t version;
+                    uint32_t entry_count;
+                    struct telemetry_entry tag_table[entry_count];
+            };
+
+            uint32_t telemetry_data[];      // SCRATCH_RAM[12] points here
+        """
+
+        try:
+            table = self.luwen_chip.axi_read32(self.__scratch_ram(13))
+            data = self.luwen_chip.axi_read32(self.__scratch_ram(12))
+            if table not in CSM_RANGE or data not in CSM_RANGE:
+                return {}
+
+            entry_count = self.luwen_chip.axi_read32(table + 4)
+            if not 0 < entry_count <= MAX_TELEMETRY_ENTRIES:
+                return {}
+
+            tag_table = self.axi_read(table + 8, entry_count * 4)
+        except Exception:
+            return {}
+
+        offsets = {}
+        for i in range(entry_count):
+            entry = int.from_bytes(tag_table[i * 4 : i * 4 + 4], "little")
+            offsets[entry & 0xFFFF] = entry >> 16
+
+        try:
+            # The length of the data array is not published, so read as far as
+            # the furthest offset any tag refers to.
+            values = self.axi_read(data, (max(offsets.values()) + 1) * 4)
+        except Exception:
+            return {}
+
+        return {
+            tag: int.from_bytes(values[offset * 4 : offset * 4 + 4], "little")
+            for tag, offset in offsets.items()
+        }
 
     def get_asic_location(self) -> int:
         """

--- a/tt_flash/compat_variables.py
+++ b/tt_flash/compat_variables.py
@@ -1,0 +1,404 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Board variables: hardware attributes that decide, together with the board type,
+whether a firmware image is compatible with the board it is about to be written
+to.
+
+Each image in a firmware bundle carries a compat-variables.json naming the
+variables it constrains, how to read each one from the board, and the values it
+permits. We evaluate those here and report which variables we managed to
+verify; firmware refuses to unlock the flash unless the variables that matter on
+the board in front of us are among them.
+
+Nothing here is specific to a particular variable. A variable whose value comes
+from a telemetry tag needs no code change, which is the point: firmware can
+start requiring a new variable and an unmodified tt-flash still honours it, so
+long as the bundle describes it. Anything we do not understand is left
+unverified rather than guessed at, so we fail closed: firmware then decides
+whether that variable mattered on this board.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum, auto
+import json
+import tarfile
+from typing import Any, Callable, Optional
+
+from tt_flash.error import TTError
+
+# The compat-variables.json format version we understand
+SUPPORTED_VERSION = 1
+
+def _format_hex(value: int) -> str:
+    return f"0x{value:x}"
+
+
+def _format_semver(value: int) -> str:
+    return f"{(value >> 24) & 0xFF}.{(value >> 16) & 0xFF}.{(value >> 8) & 0xFF}"
+
+
+# A formatter only decides how a value is printed, so an unknown one falls back
+# to hex rather than leaving the variable unverified: a newer bundle must not
+# stop an older tt-flash from doing its job, or even from explaining itself.
+FORMATTERS: dict[str, Callable[[int], str]] = {
+    "hex": _format_hex,
+    "semver": _format_semver,
+}
+
+# Every operator present in a constraint must hold
+OPERATORS: dict[str, Callable[[int, Any], bool]] = {
+    "eq": lambda value, want: value == want,
+    "ne": lambda value, want: value != want,
+    "lt": lambda value, want: value < want,
+    "le": lambda value, want: value <= want,
+    "gt": lambda value, want: value > want,
+    "ge": lambda value, want: value >= want,
+    "in": lambda value, want: value in want,
+    "not_in": lambda value, want: value not in want,
+}
+
+
+def _parse_value(value: Any) -> int:
+    """
+    Board variable values are unsigned 32 bit integers, written either as a JSON
+    integer or as a "0x..." string.
+    """
+
+    if isinstance(value, int) and not isinstance(value, bool):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = int(value, 0)
+        except ValueError:
+            raise TTError(f"Invalid board variable value {value!r}")
+    else:
+        raise TTError(f"Invalid board variable value {value!r}")
+
+    if not 0 <= parsed < 2**32:
+        raise TTError(
+            f"Board variable value {value!r} is not a 32 bit unsigned integer"
+        )
+
+    return parsed
+
+
+@dataclass
+class Variable:
+    name: str
+    number: int
+    formatter: Optional[str] = None
+    source: Optional[dict] = None
+    # The comparisons the value must satisfy, as (operator, operand) pairs, all
+    # of which must hold. Empty permits any value. None when the image
+    # constrains this variable in a way we cannot evaluate, which leaves it
+    # unverified.
+    constraints: Optional[list[tuple[str, int | list[int]]]] = None
+
+    @staticmethod
+    def loads(data: dict) -> Variable:
+        try:
+            variable = Variable(
+                name=data["name"],
+                number=data["number"],
+                formatter=data.get("formatter"),
+                source=data.get("source"),
+            )
+            constraints = data["constraints"]
+        except KeyError as e:
+            raise TTError(f"Board variable is missing {e} in compat-variables.json")
+
+        parsed: list[tuple[str, int | list[int]]] = []
+        for constraint in constraints:
+            for operator, operand in constraint.items():
+                if operator not in OPERATORS:
+                    # A newer bundle's operator. Leave constraints unset so the
+                    # variable stays unverified and firmware decides if it
+                    # mattered.
+                    variable.constraints = None
+                    return variable
+
+                if isinstance(operand, list):
+                    parsed.append((operator, [_parse_value(v) for v in operand]))
+                else:
+                    parsed.append((operator, _parse_value(operand)))
+
+        variable.constraints = parsed
+        return variable
+
+    def format(self, value: int) -> str:
+        if self.formatter is None:
+            return _format_hex(value)
+
+        formatter = FORMATTERS.get(self.formatter, _format_hex)
+        return formatter(value)
+
+    def describe_constraint(self) -> str:
+        """
+        The permitted values, phrased for the user whose board does not match.
+        """
+
+        if self.constraints is None:
+            return "values this tt-flash does not understand"
+
+        described = []
+        for operator, operand in self.constraints:
+            if isinstance(operand, list):
+                values = ", ".join(self.format(v) for v in operand)
+            else:
+                values = self.format(operand)
+
+            if operator == "eq":
+                described.append(values)
+            elif operator == "in":
+                described.append(f"one of {values}")
+            else:
+                described.append(f"{operator} {values}")
+
+        if not described:
+            return "any value"
+
+        return " and ".join(described)
+
+    def satisfied_by(self, value: int) -> bool:
+        """
+        Whether the value meets every constraint. False when the image
+        constrains this variable in a way we cannot evaluate: not a verdict
+        that the board is unsupported, only a refusal to claim it is.
+        """
+
+        if self.constraints is None:
+            return False
+
+        return all(
+            OPERATORS[operator](value, operand)
+            for operator, operand in self.constraints
+        )
+
+
+@dataclass
+class CompatVariables:
+    variables: list[Variable] = field(default_factory=list)
+    # Why we could not evaluate parts of the file, for the message we print if
+    # firmware then refuses to unlock
+    unsupported: list[str] = field(default_factory=list)
+
+    @staticmethod
+    def loads(text: str) -> CompatVariables:
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError as e:
+            raise TTError(f"Could not parse compat-variables.json: {e}")
+
+        version = data.get("version")
+        if version != SUPPORTED_VERSION:
+            # A format we don't know. Verify nothing and let firmware decide
+            # whether that mattered, rather than refusing outright on a board
+            # that needs none of this.
+            return CompatVariables(
+                unsupported=[
+                    f"compat-variables.json is version {version}, and this "
+                    f"tt-flash understands version {SUPPORTED_VERSION}"
+                ]
+            )
+
+        compat = CompatVariables()
+        for entry in data.get("variables", []):
+            variable = Variable.loads(entry)
+            compat.variables.append(variable)
+            if variable.constraints is None:
+                compat.unsupported.append(
+                    f"'{variable.name}' is constrained in a way this tt-flash "
+                    f"does not understand"
+                )
+
+        return compat
+
+    def name_of(self, number: int) -> str:
+        for variable in self.variables:
+            if variable.number == number:
+                return variable.name
+
+        return f"board variable {number}"
+
+
+def load(fw_package: tarfile.TarFile, boardname: str) -> Optional[CompatVariables]:
+    """
+    Reads the compat variables for one board out of a firmware bundle.
+
+    Bundles built before board variables existed have no such file. They
+    describe no variables, so they verify none, which is what leaves them unable
+    to unlock a board that requires any.
+    """
+
+    try:
+        contents = fw_package.extractfile(f"./{boardname}/compat-variables.json")
+    except KeyError:
+        return None
+
+    if contents is None:
+        return None
+
+    return CompatVariables.loads(contents.read().decode("utf-8"))
+
+
+def read_variable(chip, variable: Variable) -> Optional[int]:
+    """
+    Reads a board variable's value, or None if this tt-flash cannot.
+    """
+
+    source = variable.source
+    if source is None:
+        return None
+
+    if source.get("type") != "telemetry":
+        # A retrieval method we don't know about. Guessing would defeat the
+        # point of the check.
+        return None
+
+    tag = source.get("tag")
+    if tag is None:
+        return None
+
+    return chip.read_telemetry_tag(tag)
+
+
+class CheckState(Enum):
+    """What we were able to conclude about one board variable."""
+
+    #: read from the board, and the image supports it
+    PASSED = auto()
+    #: read from the board, and the image does not support it
+    FAILED = auto()
+    #: not read, so nothing was concluded either way
+    UNCHECKED = auto()
+
+
+@dataclass
+class Check:
+    """
+    The outcome of checking one board variable, and how to say it.
+
+    Every variable the image constrains produces one of these, passing or
+    not, so that a caller can report what it actually concluded rather than
+    leaving silence to stand for success.
+    """
+
+    variable: Variable
+    value: Optional[int]
+    state: CheckState
+    message: str
+
+
+def failed(checks: list[Check]) -> list[Check]:
+    return [check for check in checks if check.state is CheckState.FAILED]
+
+
+def evaluate(chip, compat: Optional[CompatVariables]) -> tuple[int, list[Check]]:
+    """
+    Checks each variable the image constrains against the board.
+
+    Returns the bitmask of variables verified against this image, where bit N is
+    variable N, and a Check for every variable the image constrains. A variable
+    we cannot read, or cannot evaluate, comes back UNCHECKED and unverified.
+    """
+
+    verified = 0
+    checks: list[Check] = []
+
+    if compat is None:
+        return verified, checks
+
+    for variable in compat.variables:
+        if variable.constraints is None:
+            checks.append(
+                Check(
+                    variable=variable,
+                    value=None,
+                    state=CheckState.UNCHECKED,
+                    message=(
+                        f"{variable.name} is constrained in a way this tt-flash "
+                        f"does not understand, so it was not checked"
+                    ),
+                )
+            )
+            continue
+
+        value = read_variable(chip, variable)
+        if value is None:
+            checks.append(
+                Check(
+                    variable=variable,
+                    value=None,
+                    state=CheckState.UNCHECKED,
+                    message=(
+                        f"{variable.name} could not be read from this board, so "
+                        f"it was not checked"
+                    ),
+                )
+            )
+            continue
+
+        if variable.satisfied_by(value):
+            verified |= 1 << variable.number
+            checks.append(
+                Check(
+                    variable=variable,
+                    value=value,
+                    state=CheckState.PASSED,
+                    message=(
+                        f"{variable.name} is {variable.format(value)}, which this "
+                        f"firmware supports"
+                    ),
+                )
+            )
+        else:
+            checks.append(
+                Check(
+                    variable=variable,
+                    value=value,
+                    state=CheckState.FAILED,
+                    message=(
+                        f"{variable.name} is {variable.format(value)}; "
+                        f"this firmware supports {variable.describe_constraint()}"
+                    ),
+                )
+            )
+
+    return verified, checks
+
+
+def describe_missing(
+    required: int, verified: int, compat: Optional[CompatVariables]
+) -> str:
+    """
+    Explains a refused FLASH_UNLOCK: which board variables the firmware needed
+    checked that we could not check.
+    """
+
+    missing = required & ~verified
+    names = [
+        compat.name_of(bit) if compat is not None else f"board variable {bit}"
+        for bit in range(32)
+        if missing & (1 << bit)
+    ]
+
+    message = (
+        "The firmware on this board will not allow a flash until these are "
+        f"verified against the image: {', '.join(names)}."
+    )
+
+    if compat is not None and compat.unsupported:
+        message += " " + " ".join(compat.unsupported) + "."
+    elif compat is None:
+        message += (
+            " This firmware bundle does not say which hardware it supports; "
+            "use a newer bundle."
+        )
+    else:
+        message += " Use a newer tt-flash or a newer firmware bundle."
+
+    return message

--- a/tt_flash/flash.py
+++ b/tt_flash/flash.py
@@ -11,6 +11,7 @@ import time
 from typing import Optional, Union
 import random
 
+from tt_flash import compat_variables
 from tt_flash.blackhole import boot_fs_write, parse_writes_from_image
 from tt_flash.blackhole import FlashWrite
 from tt_flash.chip import BhChip, TTChip, WhChip, detect_chips, resolve_board_type
@@ -98,6 +99,75 @@ class FlashResult:
     rc: int = 0
 
 
+def check_compat_variables(
+    chip: BhChip,
+    boardname: str,
+    fw_package: tarfile.TarFile,
+    debug_messages: list[str],
+    force_all_variable_checks: bool,
+) -> None:
+    """
+    Check that this image fits the board in front of us, beyond the board type
+    that selected it.
+
+    Raises TTError if it does not. Doing this before any write means an
+    incompatible image is reported cleanly, rather than partway through
+    flashing.
+    """
+
+    chip.compat_variables = compat_variables.load(fw_package, boardname)
+    verified, checks = compat_variables.evaluate(chip, chip.compat_variables)
+
+    # Report every variable, passing or not. Silence would otherwise stand for
+    # both "all supported" and "this bundle says nothing", which are very
+    # different things to be told after a flash.
+    for check in checks:
+        colour = (
+            CConfig.COLOR.GREEN
+            if check.state is compat_variables.CheckState.PASSED
+            else CConfig.COLOR.RED
+        )
+        debug_messages.append(f"\t\t\t{colour}{check.message}{CConfig.COLOR.ENDC}")
+
+    if not checks:
+        debug_messages.append(
+            f"\t\t\t{CConfig.COLOR.YELLOW}This firmware bundle does not say "
+            f"which hardware it supports{CConfig.COLOR.ENDC}"
+        )
+
+    failures = compat_variables.failed(checks)
+    if failures:
+        # Deliberately not covered by --force. Every other check --force
+        # bypasses costs at worst a wasted flash; this one decides whether the
+        # image can drive the flash part it is about to be written to, and
+        # getting it wrong leaves the board holding an image that cannot read
+        # itself back at the next boot. That board is bricked, with no recovery
+        # over PCIe.
+        if not force_all_variable_checks:
+            raise TTError(
+                "This firmware is not compatible with this board: "
+                + "; ".join(failure.message for failure in failures)
+            )
+
+        for failure in failures:
+            debug_messages.append(
+                f"\t\t\t{CConfig.COLOR.RED}WARNING:{CConfig.COLOR.ENDC} "
+                f"flashing anyway because --force-all-variable-checks was given."
+            )
+            # The check was deliberately overridden, so tell firmware it was
+            # made: without this the unlock is refused and nothing is written.
+            verified |= 1 << failure.variable.number
+
+    chip.verified_variables = verified
+
+    # Ask firmware now, so that a board whose requirements we cannot meet is
+    # reported before we start writing to it.
+    try:
+        chip.flash_unlock()
+    finally:
+        chip.flash_lock()
+
+
 def flash_chip_stage1(
     chip: TTChip,
     boardname: str,
@@ -108,6 +178,7 @@ def flash_chip_stage1(
     allow_major_downgrades: bool,
     skip_missing_fw: bool = False,
     update_boot_images: bool = False,
+    force_all_variable_checks: bool = False,
 ) -> FlashStageResult:
     """
     Check the chip and determine if it is a candidate to be flashed.
@@ -285,6 +356,11 @@ def flash_chip_stage1(
         )
     else:
         writes = parse_wh_image(chip, boardname_to_display, image, mask)
+
+    if isinstance(chip, BhChip):
+        check_compat_variables(
+            chip, boardname, fw_package, debug_messages, force_all_variable_checks
+        )
 
     if isinstance(chip, BhChip):
         can_reset = True
@@ -545,6 +621,7 @@ def flash_chip(
     allow_major_downgrades: bool,
     skip_missing_fw: bool = False,
     update_boot_images: bool = False,
+    force_all_variable_checks: bool = False,
 ) -> FlashResult:
     """
     Flash firmware to a single chip. This function is process-safe and is intended to be called by
@@ -608,6 +685,7 @@ def flash_chip(
         allow_major_downgrades,
         skip_missing_fw=skip_missing_fw,
         update_boot_images=update_boot_images,
+        force_all_variable_checks=force_all_variable_checks,
     )
 
     if result.state == FlashStageResultState.Err:

--- a/tt_flash/main.py
+++ b/tt_flash/main.py
@@ -129,6 +129,17 @@ def parse_args():
         action="store_true",
         help="Force update the ROM, bypassing the version and board checks that would otherwise stop the flash. This does not rewrite the bootloader and recovery images; pass --update-boot-images as well to do that",
     )
+    # Hidden: a board whose flash part the image cannot drive will be left
+    # holding an image that cannot read itself back at the next boot, i.e.
+    # bricked. There is no recovery over PCIe from that. This exists only for
+    # the case where the bundle's compatibility data is known to be wrong and
+    # the hardware is known to be fine.
+    flash.add_argument(
+        "--force-all-variable-checks",
+        default=False,
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
     flash.add_argument(
         "--no-reset",
         help="Do not reset devices at the end of flash",
@@ -301,7 +312,7 @@ def main():
             try:
                 # Run flash operations
                 flash_chip_args = [
-                    (dev.interface_id, fwbundle, manifest, args.force, args.allow_major_downgrades, args.skip_missing_fw, args.update_boot_images)
+                    (dev.interface_id, fwbundle, manifest, args.force, args.allow_major_downgrades, args.skip_missing_fw, args.update_boot_images, args.force_all_variable_checks)
                     for dev in devices
                 ]
                 with Pool(initializer=pool_worker_init) as p:


### PR DESCRIPTION
Due to BH Galaxy second-source SPI EEPROM, we now have board variants not supported by old firmware.

This add an interlock between tt-flash and the firmware to ensure that tt-flash won't flash firmware that can't support the board.

There are 3 participants to the interlock: the flash bundle, tt-flash and the running firmware.
- Each image in the flash bundle declares a list of board variables and the values for each variable it supports.
- tt-flash checks supported values against the actual value reported by running firmware.
- tt-flash reports to firmware which variables it checked to prevent old oblivious tt-flash from flashing incompatible firmware.

To check a supported value, tt-flash supports reading the item out of FW telemetry. That supports the only board variable today, SPI EEPROM JEDEC ID.