### PR TITLE
Fix hang flashing on Galaxy

### DIFF
--- a/tests/test_forkserver.py
+++ b/tests/test_forkserver.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests that run a real pool. These do not require hardware; the workers report
+what they inherited instead of flashing anything.
+
+The rest of the suite stands a fake pool in for the real one, which cannot show
+what a worker actually starts life with. These start workers for real, so a
+worker that quietly depends on the parent's memory shows up here.
+
+Usage:
+    pytest tests/test_forkserver.py -v
+"""
+
+import pytest
+
+from tt_flash import main, wormhole
+from tt_flash.utility import CConfig, CmdLineConfig, pool_worker_init
+
+
+def report_inherited_state(_) -> tuple:
+    """
+    Runs in a worker. Reports the state the parent set before the pool started,
+    none of which a worker gets unless it is forked from the parent.
+    """
+    return (
+        CConfig.COLOR.use_color,
+        CConfig.force_no_tty,
+        bytes(wormhole.bundle_version(None, bytearray(4), 0, 0, 4)),
+    )
+
+
+@pytest.fixture()
+def parent_state(monkeypatch) -> None:
+    """Set every piece of state to something no worker would reach by default."""
+    monkeypatch.setattr(CConfig.COLOR, "use_color", False)
+    monkeypatch.setattr(CConfig, "force_no_tty", True)
+    wormhole.set_bundle_version([19, 6, 1, 0])
+    yield
+    wormhole.set_bundle_version([0xFF, 0xFF, 0xFF, 0xFF])
+
+
+def test_flash_pool_uses_forkserver():
+    # Pool is bound to the context it came from.
+    assert main.Pool.__self__.get_start_method() == "forkserver"
+
+
+def test_a_worker_inherits_nothing_from_the_parent(parent_state):
+    """
+    The control the other tests rest on. If this ever starts seeing the
+    parent's values, workers are being forked and the rest of this file proves
+    nothing.
+    """
+    with main.Pool(processes=1) as p:
+        use_color, force_no_tty, version = p.map(report_inherited_state, [0])[0]
+
+    assert (use_color, force_no_tty) == (True, False)
+    assert version == b"\xff\xff\xff\xff"
+
+
+def test_the_initializer_gives_a_worker_the_config(parent_state):
+    """The config has to survive being pickled over to the worker."""
+    config = CmdLineConfig(use_color=False, force_no_tty=True)
+
+    with main.Pool(
+        processes=1, initializer=pool_worker_init, initargs=(config,)
+    ) as p:
+        use_color, force_no_tty, _ = p.map(report_inherited_state, [0])[0]
+
+    assert (use_color, force_no_tty) == (False, True)

--- a/tests/test_worker_state.py
+++ b/tests/test_worker_state.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for the state a pool worker sets up for itself. These do not require
+hardware: a chip of a type flash_chip does not handle stands in for a real one,
+so flash_chip returns before it touches anything.
+
+A worker inherits the parent's memory only when the pool forks. Every start
+method other than fork gives it a freshly imported module, and python 3.14
+makes forkserver the default on linux, so anything the parent set before the
+pool started has to be set again in the worker.
+
+Usage:
+    pytest tests/test_worker_state.py -v
+"""
+
+import pytest
+
+from tt_flash import flash, wormhole
+from tt_flash.flash import Manifest
+
+
+class UnsupportedChip:
+    """A chip flash_chip recognises as neither blackhole nor wormhole."""
+
+    def as_bh(self) -> None:
+        return None
+
+    def as_wh(self) -> None:
+        return None
+
+
+@pytest.fixture()
+def unflashable_chip(monkeypatch) -> None:
+    monkeypatch.setattr(flash, "PciChip", lambda interface_id: UnsupportedChip())
+
+
+def read_back_bundle_version() -> bytes:
+    """
+    The four version bytes the wh tag handler would write into an image. This
+    is the only reader of the module global, so it is what the global means.
+    """
+    return bytes(wormhole.bundle_version(None, bytearray(4), 0, 0, 4))
+
+
+def test_flash_chip_sets_the_bundle_version_it_was_given(unflashable_chip):
+    wormhole.set_bundle_version([0, 0, 0, 0])
+
+    flash.flash_chip(
+        0,
+        "unused.fwbundle",
+        Manifest(data={}, bundle_version=(19, 6, 1, 0)),
+        force=True,
+        allow_major_downgrades=False,
+        skip_missing_fw=True,
+    )
+
+    # The handler writes the four parts least significant first.
+    assert read_back_bundle_version() == bytes([0, 1, 6, 19])
+
+
+def test_flash_chip_does_not_leave_the_default_version_behind(unflashable_chip):
+    """
+    The default is 0xFFFFFFFF, and it verifies clean once written: the flash is
+    checked against the image it came from, not against the manifest. A worker
+    that never set the version would write it and report success.
+    """
+    wormhole.set_bundle_version([0xFF, 0xFF, 0xFF, 0xFF])
+
+    flash.flash_chip(
+        0,
+        "unused.fwbundle",
+        Manifest(data={}, bundle_version=(19, 6, 1, 0)),
+        force=True,
+        allow_major_downgrades=False,
+        skip_missing_fw=True,
+    )
+
+    assert read_back_bundle_version() != b"\xff\xff\xff\xff"

--- a/tests/test_worker_state.py
+++ b/tests/test_worker_state.py
@@ -15,10 +15,15 @@ Usage:
     pytest tests/test_worker_state.py -v
 """
 
+import copy
+import pickle
+import signal
+
 import pytest
 
 from tt_flash import flash, wormhole
 from tt_flash.flash import Manifest
+from tt_flash.utility import CConfig, CmdLineConfig, pool_worker_init
 
 
 class UnsupportedChip:
@@ -78,3 +83,42 @@ def test_flash_chip_does_not_leave_the_default_version_behind(unflashable_chip):
     )
 
     assert read_back_bundle_version() != b"\xff\xff\xff\xff"
+
+
+@pytest.fixture()
+def restore_worker_setup():
+    """
+    pool_worker_init changes settings a worker would keep for its whole life.
+    Put back what it changes in this process.
+    """
+    original_config = copy.copy(CConfig)
+    original_handler = signal.getsignal(signal.SIGINT)
+    yield
+    CConfig.adopt(original_config)
+    signal.signal(signal.SIGINT, original_handler)
+
+
+def test_pool_worker_init_applies_the_config(restore_worker_setup):
+    pool_worker_init(CmdLineConfig(use_color=False, force_no_tty=True))
+
+    assert CConfig.COLOR.use_color is False
+    assert CConfig.COLOR.RED == ""
+    assert CConfig.force_no_tty is True
+    assert CConfig.is_tty() is False
+
+
+def test_the_config_survives_the_trip_to_a_worker(restore_worker_setup):
+    """The pool pickles the initargs unless the worker is forked."""
+    config = CmdLineConfig(use_color=False, force_no_tty=True)
+
+    pool_worker_init(pickle.loads(pickle.dumps(config)))
+
+    assert CConfig.COLOR.use_color is False
+    assert CConfig.force_no_tty is True
+
+
+def test_pool_worker_init_ignores_sigint(restore_worker_setup):
+    """A worker must not take the interrupt that the parent is refusing."""
+    pool_worker_init(CmdLineConfig(use_color=True, force_no_tty=False))
+
+    assert signal.getsignal(signal.SIGINT) is signal.SIG_IGN

--- a/tt_flash/flash.py
+++ b/tt_flash/flash.py
@@ -482,8 +482,6 @@ def verify_package(fw_package: tarfile.TarFile, version: tuple[int, int, int]):
                 f"Bundle version {new_bundle_version} does not meet the requirements for version {'.'.join(map(str, version))}"
             )
 
-    set_bundle_version(list(new_bundle_version))
-
     return Manifest(data=manifest, bundle_version=new_bundle_version)
 
 
@@ -630,6 +628,9 @@ def flash_chip(
     (flash_chip_stage2).
     """
     debug_messages = []
+
+    # WH TAG_HANDLERS callbacks need this.
+    set_bundle_version(list(manifest.bundle_version))
 
     # Need to re-open chip in this process because chip object can't be pickled
     pci_chip = PciChip(interface_id)

--- a/tt_flash/main.py
+++ b/tt_flash/main.py
@@ -306,7 +306,9 @@ def main():
             spinner_msg = f"\t\t{CConfig.COLOR.PURPLE}Flashing devices, this might take a minute...{CConfig.COLOR.ENDC}"
             stop_spinner = threading.Event()
             spinner_thread = threading.Thread(target=spinner_task, args=(spinner_msg, stop_spinner, CConfig.is_tty()))
-            spinner_thread.start()
+            # spinner_thread.start() must be postponed until the Pool is created, otherwise forking
+            # workers may take a copy of the stdout lock while spinner_thread has it locked. But
+            # they don't take a copy of spinner_thread so nobody ever unlocks it in that process.
 
             original_handler = install_no_interrupt_handler()
             try:
@@ -316,12 +318,15 @@ def main():
                     for dev in devices
                 ]
                 with Pool(initializer=pool_worker_init) as p:
+                    # The workers are forked, so a second thread is safe now.
+                    spinner_thread.start()
                     results = p.starmap(flash_chip, flash_chip_args)
             finally:
                 restore_sigint_handler(original_handler)
-                # Stop spinner
+                # Stop spinner. ident is None if the pool raised before it started.
                 stop_spinner.set()
-                spinner_thread.join()
+                if spinner_thread.ident is not None:
+                    spinner_thread.join()
 
             # Unpack results from flash operation
             needs_reset_wh = [res.needs_reset_wh for res in results if res.needs_reset_wh is not None]

--- a/tt_flash/main.py
+++ b/tt_flash/main.py
@@ -13,7 +13,7 @@ import signal
 import sys
 import tarfile
 import threading
-from multiprocessing import Pool
+import multiprocessing
 from pathlib import Path
 
 import tt_flash
@@ -35,6 +35,13 @@ from tt_flash.flash import (
 )
 
 from .chip import detect_local_chips, validate_p300_can_be_flashed
+
+# Flash workers are forked from a forkserver, a process that does nothing but
+# fork and so is always single-threaded, rather than from this process, which
+# is not. Python 3.14 makes this the default on linux; naming it keeps every
+# version this package supports on the same start method, and keeps the choice
+# somewhere it can be read.
+Pool = multiprocessing.get_context("forkserver").Pool
 
 
 # Make version available in --help
@@ -319,7 +326,8 @@ def main():
                     for dev in devices
                 ]
                 with Pool(initializer=pool_worker_init, initargs=(CConfig,)) as p:
-                    # The workers are forked, so a second thread is safe now.
+                    # Workers come from the forkserver now, so the order is
+                    # no longer load-bearing, but it costs nothing to keep.
                     spinner_thread.start()
                     results = p.starmap(flash_chip, flash_chip_args)
             finally:

--- a/tt_flash/main.py
+++ b/tt_flash/main.py
@@ -247,6 +247,7 @@ def load_manifest(path: str):
 
 
 def main():
+    multiprocessing.freeze_support()
     parser, args = parse_args()
 
     CConfig.force_no_tty = args.no_tty

--- a/tt_flash/main.py
+++ b/tt_flash/main.py
@@ -317,7 +317,7 @@ def main():
                     (dev.interface_id, fwbundle, manifest, args.force, args.allow_major_downgrades, args.skip_missing_fw, args.update_boot_images, args.force_all_variable_checks)
                     for dev in devices
                 ]
-                with Pool(initializer=pool_worker_init) as p:
+                with Pool(initializer=pool_worker_init, initargs=(CConfig,)) as p:
                     # The workers are forked, so a second thread is safe now.
                     spinner_thread.start()
                     results = p.starmap(flash_chip, flash_chip_args)

--- a/tt_flash/utility.py
+++ b/tt_flash/utility.py
@@ -176,7 +176,11 @@ class ConfigurableCmdColor:
         self.use_color = use_color
 
     def __getattr__(self, k):
-        if k == "use_color":
+        if k.startswith("__"):
+            # Answer no special method lookups: pickle asks for __getstate__
+            # and must not be handed a colour code.
+            raise AttributeError(k)
+        elif k == "use_color":
             return self.use_color
         elif self.use_color:
             return getattr(CMD_LINE_COLOR, k)
@@ -192,12 +196,29 @@ class CmdLineConfig:
     def is_tty(self) -> bool:
         return (not self.force_no_tty) and sys.stdout.isatty()
 
+    def adopt(self, other: "CmdLineConfig") -> None:
+        """
+        Take on every setting of another instance.
+
+        Each module that prints reads the CConfig it imported, so the settings
+        have to land in that instance; rebinding the name would not reach them.
+        """
+        self.__dict__.update(vars(other))
+
 
 CConfig = CmdLineConfig(True, False)
 
-def pool_worker_init():
-    """Ignore SIGINT on multiprocessing pool worker init"""
+def pool_worker_init(config: CmdLineConfig) -> None:
+    """
+    Set up a multiprocessing pool worker.
+
+    The config comes from the command line, which only the parent parsed, so it
+    is passed in rather than read from this process's own CConfig: a worker that
+    was not forked starts with the defaults, and would colour its messages
+    against --no-color.
+    """
     signal.signal(signal.SIGINT, signal.SIG_IGN)
+    CConfig.adopt(config)
 
 def install_no_interrupt_handler():
     """


### PR DESCRIPTION
tt-flash would randomly hang on galaxy due to a race between creating the worker child processes and the spinner thread locking stdout. Child processes created while stdout was locked will eternally see it as locked.
